### PR TITLE
Maximum defensive code to avoid fatal failure when registry is broken

### DIFF
--- a/modules/openlayers_block/openlayers_block.module
+++ b/modules/openlayers_block/openlayers_block.module
@@ -7,7 +7,7 @@ function openlayers_block_block_info() {
   $blocks = array();
 
   foreach (\Drupal\openlayers\Openlayers::loadAll('Map') as $map) {
-    if ($map->getOption('provideBlock', FALSE)) {
+    if ($map && $map->getOption('provideBlock', FALSE)) {
       $key = _openlayers_block_get_block_id($map->machine_name);
       $blocks[$key]['info'] = t('OpenLayers block for @map_name', array('@map_name' => $map->name));
     }
@@ -62,7 +62,7 @@ function _openlayers_block_get_block_id($map_machine_name) {
  */
 function _openlayers_block_get_map_name($delta) {
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Map') as $map) {
-    if (_openlayers_block_get_block_id($map->machine_name) == $delta) {
+    if ($map && _openlayers_block_get_block_id($map->machine_name) == $delta) {
       return $map->machine_name;
     }
   }
@@ -70,13 +70,13 @@ function _openlayers_block_get_map_name($delta) {
 }
 
 function openlayers_block_form_openlayers_map_form_settings_alter(&$form, &$form_state) {
-  $map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item']);
-
-  $form['options']['ui']['provideBlock'] = array(
-    '#type' => 'checkbox',
-    '#title' => 'Provide Drupal block for this map ?',
-    '#description' => t('Enable this to provide a Drupal block for this map.'),
-    '#default_value' => $map->getOption('provideBlock', FALSE),
-    '#parents' => array('options', 'provideBlock'),
-  );
+  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
+    $form['options']['ui']['provideBlock'] = array(
+      '#type' => 'checkbox',
+      '#title' => 'Provide Drupal block for this map ?',
+      '#description' => t('Enable this to provide a Drupal block for this map.'),
+      '#default_value' => $map->getOption('provideBlock', FALSE),
+      '#parents' => array('options', 'provideBlock'),
+    );
+  }
 }

--- a/modules/openlayers_block_switcher/openlayers_block_switcher.module
+++ b/modules/openlayers_block_switcher/openlayers_block_switcher.module
@@ -25,11 +25,11 @@ function openlayers_block_switcher_block_info() {
 function openlayers_block_switcher_block_view($delta = '') {
   $block = array();
   /** @var \Drupal\openlayers\Plugin\Map\OLMap\OLMap $map */
-  $map = \Drupal\openlayers\Openlayers::load('Map', _olebs_get_map_name($delta));
-
-  $block['subject'] = $map->name;
-  $form = drupal_get_form('olebs_blockswitcher_form', $map);
-  $block['content'] = drupal_render($form);
+  if ($map = \Drupal\openlayers\Openlayers::load('Map', _olebs_get_map_name($delta))) {
+    $block['subject'] = $map->name;
+    $form = drupal_get_form('olebs_blockswitcher_form', $map);
+    $block['content'] = drupal_render($form);
+  }
 
   return $block;
 }
@@ -47,7 +47,7 @@ function _olebs_get_maps_with_blockswitcher() {
 
   if (!isset($maps)) {
     foreach(\Drupal\openlayers\Openlayers::loadAll('Map') as $map) {
-      if ($map->getOption('provideBlockLayerSwitcher', FALSE) == TRUE) {
+      if ($map && $map->getOption('provideBlockLayerSwitcher', FALSE) == TRUE) {
         $maps[] = $map;
       }
     }
@@ -131,13 +131,13 @@ function olebs_blockswitcher_form($form, &$form_state, $map) {
 }
 
 function openlayers_block_switcher_form_openlayers_map_form_settings_alter(&$form, &$form_state) {
-  $map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item']);
-
-  $form['options']['ui']['provideBlockLayerSwitcher'] = array(
-    '#type' => 'checkbox',
-    '#title' => 'Provide Drupal block layer switcher',
-    '#description' => t('Enable this to enable a Drupal block to display a layer switcher.'),
-    '#default_value' => $map->getOption('provideBlockLayerSwitcher', FALSE),
-    '#parents' => array('options', 'provideBlockLayerSwitcher'),
-  );
+  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
+    $form['options']['ui']['provideBlockLayerSwitcher'] = array(
+      '#type' => 'checkbox',
+      '#title' => 'Provide Drupal block layer switcher',
+      '#description' => t('Enable this to enable a Drupal block to display a layer switcher.'),
+      '#default_value' => $map->getOption('provideBlockLayerSwitcher', FALSE),
+      '#parents' => array('options', 'provideBlockLayerSwitcher'),
+    );
+  }
 }

--- a/modules/openlayers_contextual_links/openlayers_contextual_links.module
+++ b/modules/openlayers_contextual_links/openlayers_contextual_links.module
@@ -74,13 +74,14 @@ function openlayers_contextual_links_openlayers_object_postprocess_alter(&$build
 }
 
 function openlayers_contextual_links_form_openlayers_map_form_settings_alter(&$form, &$form_state) {
-  $map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item']);
+  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
 
-  $form['options']['ui']['contextualLinks'] = array(
-    '#type' => 'checkbox',
-    '#title' => 'Contextual links',
-    '#description' => t('Enable contextual links on the map.'),
-    '#default_value' => $map->getOption('contextualLinks', FALSE),
-    '#parents' => array('options', 'contextualLinks'),
-  );
+    $form['options']['ui']['contextualLinks'] = array(
+      '#type' => 'checkbox',
+      '#title' => 'Contextual links',
+      '#description' => t('Enable contextual links on the map.'),
+      '#default_value' => $map->getOption('contextualLinks', FALSE),
+      '#parents' => array('options', 'contextualLinks'),
+    );
+  }
 }

--- a/modules/openlayers_examples/openlayers_examples.module
+++ b/modules/openlayers_examples/openlayers_examples.module
@@ -39,7 +39,7 @@ function openlayers_examples($form, &$form_state, $map_arg = NULL) {
   $maps = array();
   $options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Map') as $machine_name => $data) {
-    if (property_exists($data, 'disabled') && ($data->disabled == 1 || $data->disabled == TRUE)) {
+    if (!$data || (property_exists($data, 'disabled') && ($data->disabled == 1 || $data->disabled == TRUE))) {
       continue;
     }
     $options[$machine_name] = $data->name;
@@ -83,7 +83,9 @@ function openlayers_examples($form, &$form_state, $map_arg = NULL) {
   );
 
   foreach ($maps as $map) {
-    $map = \Drupal\openlayers\Openlayers::load('Map', $map);
+    if (!($map = \Drupal\openlayers\Openlayers::load('Map', $map))) {
+      continue;
+    }
 
     $form['form'][$map->getId()] = array(
       '#type' => 'fieldset',

--- a/modules/openlayers_geofield/openlayers_geofield.module
+++ b/modules/openlayers_geofield/openlayers_geofield.module
@@ -53,10 +53,12 @@ function openlayers_geofield_field_formatter_settings_form($field, $instance, $v
   // Get preset options, filtered to those which have the GeoField source.
   $map_options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAll('Map') as $machine_name => $map) {
-    foreach ($map->getObjects('source') as $source) {
-      // TODO: add getSource() to Object and Object Interface.
-      if ($source instanceof \Drupal\openlayers_geofield\Plugin\Source\Geofield\Geofield) {
-        $map_options[$machine_name] = $map->name;
+    if ($map) {
+      foreach ($map->getObjects('source') as $source) {
+        // TODO: add getSource() to Object and Object Interface.
+        if ($source instanceof \Drupal\openlayers_geofield\Plugin\Source\Geofield\Geofield) {
+          $map_options[$machine_name] = $map->name;
+        }
       }
     }
   }
@@ -111,8 +113,9 @@ function openlayers_geofield_field_formatter_settings_summary($field, $instance,
   }
 
   if ($display['type'] == 'openlayers_geofield' && !empty($settings['map_preset'])) {
-    $map = \Drupal\openlayers\Openlayers::load('Map', $settings['map_preset']);
-    $summary[] = t('Openlayers Map: @data', array('@data' => $map->name));
+    if ($map = \Drupal\openlayers\Openlayers::load('Map', $settings['map_preset'])) {
+      $summary[] = t('Openlayers Map: @data', array('@data' => $map->name));
+    }
   }
 
   if (!empty($settings['address']) && $settings['address']) {
@@ -201,20 +204,21 @@ function openlayers_geofield_field_formatter_view($entity_type, $entity, $field,
 
   // Load map and set features.
   $map_name = $display['settings']['map_preset'] ? $display['settings']['map_preset'] : 'openlayers_geofield_map_geofield_formatter';
-  $map = \Drupal\openlayers\Openlayers::load('Map', $map_name);
-  $geofield_source = NULL;
-  foreach ($map->getObjects('source') as $source) {
-    if ($source instanceof \Drupal\openlayers_geofield\Plugin\Source\Geofield\Geofield) {
-      $geofield_source = $source;
-      $source->setOption('features', $features);
+  if ($map = \Drupal\openlayers\Openlayers::load('Map', $map_name)) {
+    $geofield_source = NULL;
+    foreach ($map->getObjects('source') as $source) {
+      if ($source instanceof \Drupal\openlayers_geofield\Plugin\Source\Geofield\Geofield) {
+        $geofield_source = $source;
+        $source->setOption('features', $features);
+      }
     }
-  }
-  if (!isset($geofield_source)) {
-    drupal_set_message(t('Trying to render a geofield formatter on a map without the geofield source.'), 'error');
-  }
+    if (!isset($geofield_source)) {
+      drupal_set_message(t('Trying to render a geofield formatter on a map without the geofield source.'), 'error');
+    }
 
-  // Build map.
-  $element[0] = $map->build();
+    // Build map.
+    $element[0] = $map->build();
+  }
   return $element;
 }
 
@@ -261,9 +265,11 @@ function openlayers_geofield_field_widget_settings_form($field, $instance) {
   $maps = \Drupal\openlayers\Openlayers::loadAll('Map');
   $map_options = array();
   foreach ($maps as $machine_name => $map) {
-    foreach ($map->getObjects('component') as $component) {
-      if ($component instanceof \Drupal\openlayers_geofield\Plugin\Component\Geofield\Geofield) {
-        $map_options[$machine_name] = $map->name;
+    if ($map) {
+      foreach ($map->getObjects('component') as $component) {
+        if ($component instanceof \Drupal\openlayers_geofield\Plugin\Component\Geofield\Geofield) {
+          $map_options[$machine_name] = $map->name;
+        }
       }
     }
   }
@@ -386,7 +392,10 @@ function openlayers_geofield_field_widget_form(&$form, &$form_state, $field, $in
 
   $openlayers_map_id = !empty($instance['widget']['settings']['openlayers_map']) ? $instance['widget']['settings']['openlayers_map'] : 'openlayers_geofield_map_geofield';
 
-  $map = \Drupal\openlayers\Openlayers::load('Map', $openlayers_map_id);
+  if (!($map = \Drupal\openlayers\Openlayers::load('Map', $openlayers_map_id))) {
+    // If the map couldn't be load we can't do a thing.
+    return NULL;
+  }
   foreach ($map->getObjects('component') as $component) {
     // Configure component based on the widget settings.
     if ($component instanceof \Drupal\openlayers_geofield\Plugin\Component\Geofield\Geofield) {

--- a/modules/openlayers_services/openlayers_services.helpers.inc
+++ b/modules/openlayers_services/openlayers_services.helpers.inc
@@ -5,20 +5,21 @@
  */
 
 function _openlayers_services_retrieve($name) {
-  $map = \Drupal\openlayers\Openlayers::load('Map', $name);
-  $build = $map->build();
-  $render = drupal_render($build);
-  $js = drupal_get_js();
-  $styles = drupal_get_css();
+  if ($map = \Drupal\openlayers\Openlayers::load('Map', $name)) {
+    $build = $map->build();
+    $render = drupal_render($build);
+    $js = drupal_get_js();
+    $styles = drupal_get_css();
 
-  return theme('openlayers_map_iframe', array(
-    'page' => $render,
-    'scripts' => $js,
-    'styles' => $styles,
-  ));
+    return theme('openlayers_map_iframe', array(
+      'page' => $render,
+      'scripts' => $js,
+      'styles' => $styles,
+    ));
+  }
 }
 
 function _openlayers_services_access($operation, $map) {
   $map = \Drupal\openlayers\Openlayers::load('Map', $map[0]);
-  return (bool) $map->getOption('provideIframe', FALSE);
+  return $map && (bool) $map->getOption('provideIframe', FALSE);
 }

--- a/modules/openlayers_services/openlayers_services.module
+++ b/modules/openlayers_services/openlayers_services.module
@@ -64,21 +64,22 @@ function openlayers_services_theme($existing, $type, $theme, $path) {
 }
 
 function openlayers_services_form_openlayers_map_form_settings_alter(&$form, &$form_state) {
-  $map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']);
+  if ($map = \Drupal\openlayers\Openlayers::load('map', $form_state['item'])) {
 
-  $form['options']['ui']['provideIframe'] = array(
-    '#type' => 'checkbox',
-    '#title' => 'Provide iframe of this map ?',
-    '#description' => t('Enable this to provide this map as an iframe through the service module.'),
-    '#default_value' => $map->getOption('provideIframe', FALSE),
-    '#parents' => array('options', 'provideIframe'),
-  );
+    $form['options']['ui']['provideIframe'] = array(
+      '#type' => 'checkbox',
+      '#title' => 'Provide iframe of this map ?',
+      '#description' => t('Enable this to provide this map as an iframe through the service module.'),
+      '#default_value' => $map->getOption('provideIframe', FALSE),
+      '#parents' => array('options', 'provideIframe'),
+    );
+  }
 }
 
 function openlayers_services_form_openlayers_map_form_preview_alter(&$form, &$form_state) {
   $map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']);
 
-  if ((bool) $map->getOption('provideIframe', FALSE) == FALSE) {
+  if (!$map || (bool) $map->getOption('provideIframe', FALSE) == FALSE) {
     return;
   }
 

--- a/modules/openlayers_ui/includes/openlayers_ui.admin.inc
+++ b/modules/openlayers_ui/includes/openlayers_ui.admin.inc
@@ -14,7 +14,7 @@
 function openlayers_ui_admin_settings($form, &$form_state) {
   $options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Map') as $machine_name => $data) {
-    if (property_exists($data, 'disabled') && ($data->disabled == 1 || $data->disabled == TRUE)) {
+    if (!$data || (property_exists($data, 'disabled') && ($data->disabled == 1 || $data->disabled == TRUE))) {
       continue;
     }
     $options[$machine_name] = $data->name;

--- a/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersComponents.inc
+++ b/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersComponents.inc
@@ -77,7 +77,7 @@ function openlayers_component_form_start($form, &$form_state) {
 
   $options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Map') as $machine_name => $map) {
-    if (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE)) {
+    if (!$map || (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE))) {
       continue;
     }
     $options[$machine_name] = $map->name;
@@ -141,9 +141,10 @@ function openlayers_component_form_type_submit($form, &$form_state) {
  * Component options form handler.
  */
 function openlayers_component_form_options($form, &$form_state) {
-  $component = \Drupal\openlayers\Openlayers::load('Component', $form_state['item']);
-  $component->optionsForm($form, $form_state);
-  $form['options']['#tree'] = TRUE;
+  if ($component = \Drupal\openlayers\Openlayers::load('Component', $form_state['item'])) {
+    $component->optionsForm($form, $form_state);
+    $form['options']['#tree'] = TRUE;
+  }
 
   return $form;
 }
@@ -152,8 +153,9 @@ function openlayers_component_form_options($form, &$form_state) {
  * Component options form validation handler.
  */
 function openlayers_component_form_options_validate($form, &$form_state) {
-  $component = \Drupal\openlayers\Openlayers::load('Component', $form_state['item']);
-  $component->optionsFormValidate($form, $form_state);
+  if ($component = \Drupal\openlayers\Openlayers::load('Component', $form_state['item'])) {
+    $component->optionsFormValidate($form, $form_state);
+  }
 }
 
 /**
@@ -164,13 +166,13 @@ function openlayers_component_form_options_submit($form, &$form_state) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
 
-  if (!empty($form_state['item']->attachToMap)) {
-    $map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap);
-    $map->getCollection()->append(\Drupal\openlayers\Openlayers::load('component', $form_state['item']));
-    \Drupal\openlayers\Openlayers::save($map);
-    unset($form_state['item']->attachToMap);
-  }
+  if ($component = \Drupal\openlayers\Openlayers::load('Component', $form_state['item'])) {
+    if (!empty($form_state['item']->attachToMap) && ($map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap))) {
+      $map->getCollection()->append($component);
+      \Drupal\openlayers\Openlayers::save($map);
+      unset($form_state['item']->attachToMap);
+    }
 
-  $component = \Drupal\openlayers\Openlayers::load('Component', $form_state['item']);
-  $component->optionsFormSubmit($form, $form_state);
+    $component->optionsFormSubmit($form, $form_state);
+  }
 }

--- a/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersControls.inc
+++ b/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersControls.inc
@@ -77,7 +77,7 @@ function openlayers_control_form_start($form, &$form_state) {
 
   $options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Map') as $machine_name => $map) {
-    if (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE)) {
+    if (!$map || (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE))) {
       continue;
     }
     $options[$machine_name] = $map->name;
@@ -141,9 +141,10 @@ function openlayers_control_form_type_submit($form, &$form_state) {
  * Control options config form handler.
  */
 function openlayers_control_form_options($form, &$form_state) {
-  $control = \Drupal\openlayers\Openlayers::load('Control', $form_state['item']);
-  $control->optionsForm($form, $form_state);
-  $form['options']['#tree'] = TRUE;
+  if ($control = \Drupal\openlayers\Openlayers::load('Control', $form_state['item'])) {
+    $control->optionsForm($form, $form_state);
+    $form['options']['#tree'] = TRUE;
+  }
 
   return $form;
 }
@@ -152,8 +153,9 @@ function openlayers_control_form_options($form, &$form_state) {
  * Control options config form validation handler.
  */
 function openlayers_control_form_options_validate($form, &$form_state) {
-  $control = \Drupal\openlayers\Openlayers::load('Control', $form_state['item']);
-  $control->optionsFormValidate($form, $form_state);
+  if ($control = \Drupal\openlayers\Openlayers::load('Control', $form_state['item'])) {
+    $control->optionsFormValidate($form, $form_state);
+  }
 }
 
 /**
@@ -164,13 +166,13 @@ function openlayers_control_form_options_submit($form, &$form_state) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
 
-  if (!empty($form_state['item']->attachToMap)) {
-    $map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap);
-    $map->getCollection()->append(\Drupal\openlayers\Openlayers::load('control', $form_state['item']));
-    \Drupal\openlayers\Openlayers::save($map);
-    unset($form_state['item']->attachToMap);
-  }
+  if ($control = \Drupal\openlayers\Openlayers::load('Control', $form_state['item'])) {
+    if (!empty($form_state['item']->attachToMap) && $map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap)) {
+      $map->getCollection()->append($control);
+      \Drupal\openlayers\Openlayers::save($map);
+      unset($form_state['item']->attachToMap);
+    }
 
-  $control = \Drupal\openlayers\Openlayers::load('Control', $form_state['item']);
-  $control->optionsFormSubmit($form, $form_state);
+    $control->optionsFormSubmit($form, $form_state);
+  }
 }

--- a/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersInteractions.inc
+++ b/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersInteractions.inc
@@ -77,7 +77,7 @@ function openlayers_interaction_form_start($form, &$form_state) {
 
   $options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Map') as $machine_name => $map) {
-    if (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE)) {
+    if (!$map || (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE))) {
       continue;
     }
     $options[$machine_name] = $map->name;
@@ -141,9 +141,10 @@ function openlayers_interaction_form_type_submit($form, &$form_state) {
  * Interaction options config form handler.
  */
 function openlayers_interaction_form_options($form, &$form_state) {
-  $interaction = \Drupal\openlayers\Openlayers::load('Interaction', $form_state['item']);
-  $interaction->optionsForm($form, $form_state);
-  $form['options']['#tree'] = TRUE;
+  if ($interaction = \Drupal\openlayers\Openlayers::load('Interaction', $form_state['item'])) {
+    $interaction->optionsForm($form, $form_state);
+    $form['options']['#tree'] = TRUE;
+  }
 
   return $form;
 }
@@ -152,8 +153,9 @@ function openlayers_interaction_form_options($form, &$form_state) {
  * Interaction options config form validation handler.
  */
 function openlayers_interaction_form_options_validate($form, &$form_state) {
-  $interaction = \Drupal\openlayers\Openlayers::load('Interaction', $form_state['item']);
-  $interaction->optionsFormValidate($form, $form_state);
+  if ($interaction = \Drupal\openlayers\Openlayers::load('Interaction', $form_state['item'])) {
+    $interaction->optionsFormValidate($form, $form_state);
+  }
 }
 
 /**
@@ -164,13 +166,13 @@ function openlayers_interaction_form_options_submit($form, &$form_state) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
 
-  if (!empty($form_state['item']->attachToMap)) {
-    $map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap);
-    $map->getCollection()->append(\Drupal\openlayers\Openlayers::load('interaction', $form_state['item']));
-    \Drupal\openlayers\Openlayers::save($map);
-    unset($form_state['item']->attachToMap);
-  }
+  if ($interaction = \Drupal\openlayers\Openlayers::load('Interaction', $form_state['item'])) {
+    if (!empty($form_state['item']->attachToMap) && $map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap)) {
+      $map->getCollection()->append($interaction);
+      \Drupal\openlayers\Openlayers::save($map);
+      unset($form_state['item']->attachToMap);
+    }
 
-  $interaction = \Drupal\openlayers\Openlayers::load('Interaction', $form_state['item']);
-  $interaction->optionsFormSubmit($form, $form_state);
+    $interaction->optionsFormSubmit($form, $form_state);
+  }
 }

--- a/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersLayers.inc
+++ b/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersLayers.inc
@@ -81,7 +81,7 @@ function openlayers_layer_form_start($form, &$form_state) {
 
   $options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Map') as $machine_name => $map) {
-    if (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE)) {
+    if (!$map || (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE))) {
       continue;
     }
     $options[$machine_name] = $map->name;
@@ -199,9 +199,10 @@ function openlayers_layer_form_style_submit($form, &$form_state) {
  * Layer options config form handler.
  */
 function openlayers_layer_form_options($form, &$form_state) {
-  $layer = \Drupal\openlayers\Openlayers::load('Layer', $form_state['item']);
-  $layer->optionsForm($form, $form_state);
-  $form['options']['#tree'] = TRUE;
+  if ($layer = \Drupal\openlayers\Openlayers::load('Layer', $form_state['item'])) {
+    $layer->optionsForm($form, $form_state);
+    $form['options']['#tree'] = TRUE;
+  }
 
   return $form;
 }
@@ -210,8 +211,9 @@ function openlayers_layer_form_options($form, &$form_state) {
  * Layer options config form validation handler.
  */
 function openlayers_layer_form_options_validate($form, &$form_state) {
-  $layer = \Drupal\openlayers\Openlayers::load('Layer', $form_state['item']);
-  $layer->optionsFormValidate($form, $form_state);
+  if ($layer = \Drupal\openlayers\Openlayers::load('Layer', $form_state['item'])) {
+    $layer->optionsFormValidate($form, $form_state);
+  }
 }
 
 /**
@@ -222,13 +224,13 @@ function openlayers_layer_form_options_submit($form, &$form_state) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
 
-  if (!empty($form_state['item']->attachToMap)) {
-    $map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap);
-    $map->getCollection()->append(\Drupal\openlayers\Openlayers::load('layer', $form_state['item']));
-    \Drupal\openlayers\Openlayers::save($map);
-    unset($form_state['item']->attachToMap);
-  }
+  if ($layer = \Drupal\openlayers\Openlayers::load('Layer', $form_state['item'])) {
+    if (!empty($form_state['item']->attachToMap) && $map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap)) {
+      $map->getCollection()->append($layer);
+      \Drupal\openlayers\Openlayers::save($map);
+      unset($form_state['item']->attachToMap);
+    }
 
-  $layer = \Drupal\openlayers\Openlayers::load('Layer', $form_state['item']);
-  $layer->optionsFormSubmit($form, $form_state);
+    $layer->optionsFormSubmit($form, $form_state);
+  }
 }

--- a/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersMaps.inc
+++ b/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersMaps.inc
@@ -122,9 +122,10 @@ function openlayers_map_form_settings($form, &$form_state) {
   if (!isset($form_state['item']->factory_service)) {
     $form_state['item']->factory_service = 'openlayers.Map:OLMap';
   }
-  $map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item']);
-  $map->optionsForm($form, $form_state);
-  $form['options']['#tree'] = TRUE;
+  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
+    $map->optionsForm($form, $form_state);
+    $form['options']['#tree'] = TRUE;
+  }
 
   return $form;
 }
@@ -141,8 +142,9 @@ function openlayers_map_form_settings_validate($form, &$form_state) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
 
-  $map = \Drupal\openlayers\Openlayers::load('Map', $item);
-  $map->optionsFormValidate($form, $form_state);
+  if ($map = \Drupal\openlayers\Openlayers::load('Map', $item)) {
+    $map->optionsFormValidate($form, $form_state);
+  }
 }
 
 /**
@@ -157,8 +159,9 @@ function openlayers_map_form_settings_submit($form, &$form_state) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
 
-  $map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item']);
-  $map->optionsFormSubmit($form, $form_state);
+  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
+    $map->optionsFormSubmit($form, $form_state);
+  }
 }
 
 /**
@@ -166,7 +169,9 @@ function openlayers_map_form_settings_submit($form, &$form_state) {
  */
 function openlayers_map_form_layers($form, &$form_state) {
   $all_layers = \Drupal\openlayers\Openlayers::loadAllExportable('Layer');
-  $map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item']);
+  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
+    return;
+  }
 
   $layers = array();
   foreach ($map->getObjects('layer') as $layer) {
@@ -184,15 +189,17 @@ function openlayers_map_form_layers($form, &$form_state) {
   $i = 0;
   /* @var \Drupal\openlayers\Types\Layer $layer */
   foreach ($layers as $machine_name => $layer) {
-    $data[$machine_name] = array(
-      'name' => $layer->name,
-      'machine_name' => $layer->machine_name,
-      'factory_service' => $layer->factory_service,
-      'weight' => $i++,
-      'enable' => isset($layer->enable) ? $layer->enable : 0,
-      'default' => 1,
-      'style' => isset($layer->options['style']) ? $layer->options['style'] : NULL
-    );
+    if ($layer) {
+      $data[$machine_name] = array(
+        'name' => $layer->name,
+        'machine_name' => $layer->machine_name,
+        'factory_service' => $layer->factory_service,
+        'weight' => $i++,
+        'enable' => isset($layer->enable) ? $layer->enable : 0,
+        'default' => 1,
+        'style' => isset($layer->options['style']) ? $layer->options['style'] : NULL
+      );
+    }
   }
 
   $rows = array();
@@ -289,15 +296,16 @@ function openlayers_map_form_layers($form, &$form_state) {
   drupal_add_tabledrag('entry-order-layers', 'order', 'sibling', 'entry-order-weight');
 
   $all_sources = \Drupal\openlayers\Openlayers::loadAllExportable('Source');
-  /* @var \Drupal\openlayers\Types\Map $map */
-  $map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item']);
 
   $sources = array();
-  foreach ($map->getObjects('source') as $source) {
-    if (isset($all_sources[$source->machine_name])) {
-      $sources[$source->machine_name] = $all_sources[$source->machine_name];
-      $sources[$source->machine_name]->enable = 1;
-      unset($all_sources[$source->machine_name]);
+  /* @var \Drupal\openlayers\Types\Map $map */
+  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
+    foreach ($map->getObjects('source') as $source) {
+      if (isset($all_sources[$source->machine_name])) {
+        $sources[$source->machine_name] = $all_sources[$source->machine_name];
+        $sources[$source->machine_name]->enable = 1;
+        unset($all_sources[$source->machine_name]);
+      }
     }
   }
 
@@ -307,14 +315,16 @@ function openlayers_map_form_layers($form, &$form_state) {
 
   $i = 0;
   foreach ($sources as $machine_name => $source) {
-    $data[$machine_name] = array(
-      'name' => $source->name,
-      'machine_name' => $source->machine_name,
-      'factory_service' => $source->factory_service,
-      'weight' => $i++,
-      'enable' => isset($source->enable) ? $source->enable : 0,
-      'default' => 1,
-    );
+    if ($source) {
+      $data[$machine_name] = array(
+        'name' => $source->name,
+        'machine_name' => $source->machine_name,
+        'factory_service' => $source->factory_service,
+        'weight' => $i++,
+        'enable' => isset($source->enable) ? $source->enable : 0,
+        'default' => 1,
+      );
+    }
   }
 
   $rows = array();
@@ -405,15 +415,17 @@ function openlayers_map_form_layers_submit($form, &$form_state) {
       $layers_enabled[$data['weight']] = $id;
 
       //Update the layer style.
-      $layer = \Drupal\openlayers\Openlayers::load('layer', $data['machine_name']);
-      if (!is_null($data['style'])) {
-        if ($data['style'] != $layer->getOption('style')) {
-          $layer->setOption('style', $data['style']);
+      if ($layer = \Drupal\openlayers\Openlayers::load('layer', $data['machine_name'])) {
+        if (!is_null($data['style'])) {
+          if ($data['style'] != $layer->getOption('style')) {
+            $layer->setOption('style', $data['style']);
+          }
         }
-      } else {
-        $layer->clearOption('style');
+        else {
+          $layer->clearOption('style');
+        }
+        \Drupal\openlayers\Openlayers::save($layer);
       }
-      \Drupal\openlayers\Openlayers::save($layer);
     }
   }
 
@@ -456,14 +468,16 @@ function openlayers_map_form_controls($form, &$form_state) {
 
   $i = 0;
   foreach ($all_controls as $machine_name => $control) {
-    $data[$machine_name] = array(
-      'name' => $control->name,
-      'machine_name' => $control->machine_name,
-      'description' => $control->description,
-      'weight' => $i++,
-      'enable' => (int) in_array($control->machine_name, $form_state['item']->options['controls']),
-      'default' => 1,
-    );
+    if ($control) {
+      $data[$machine_name] = array(
+        'name' => $control->name,
+        'machine_name' => $control->machine_name,
+        'description' => $control->description,
+        'weight' => $i++,
+        'enable' => (int) in_array($control->machine_name, $form_state['item']->options['controls']),
+        'default' => 1,
+      );
+    }
   }
 
   $rows = array();
@@ -576,20 +590,22 @@ function openlayers_map_form_interactions($form, &$form_state) {
 
   $rows = array();
   foreach ($all_interactions as $machine_name => $interaction) {
-    $rows[$machine_name] = array(
-      'name' => $interaction->name,
-      'machine_name' => $interaction->machine_name,
-      'description' => $interaction->description,
-      'operations' => l(
-        t('Edit'),
-        'admin/structure/openlayers/interactions/list/' . $machine_name . '/edit/options',
-        array(
-          'query' => array(
-            'destination' => current_path(),
-          ),
-        )
-      ),
-    );
+    if ($interaction) {
+      $rows[$machine_name] = array(
+        'name' => $interaction->name,
+        'machine_name' => $interaction->machine_name,
+        'description' => $interaction->description,
+        'operations' => l(
+          t('Edit'),
+          'admin/structure/openlayers/interactions/list/' . $machine_name . '/edit/options',
+          array(
+            'query' => array(
+              'destination' => current_path(),
+            ),
+          )
+        ),
+      );
+    }
   }
 
   $form['options']['#tree'] = TRUE;
@@ -640,14 +656,16 @@ function openlayers_map_form_components($form, &$form_state) {
 
   $i = 0;
   foreach ($all_components as $machine_name => $component) {
-    $data[$machine_name] = array(
-      'name' => $component->name,
-      'machine_name' => $component->machine_name,
-      'description' => $component->description,
-      'weight' => $i++,
-      'enable' => (int) in_array($component->machine_name, $form_state['item']->options['components']),
-      'default' => 1,
-    );
+    if ($component) {
+      $data[$machine_name] = array(
+        'name' => $component->name,
+        'machine_name' => $component->machine_name,
+        'description' => $component->description,
+        'weight' => $i++,
+        'enable' => (int) in_array($component->machine_name, $form_state['item']->options['components']),
+        'default' => 1,
+      );
+    }
   }
 
   $rows = array();
@@ -759,9 +777,9 @@ function openlayers_map_form_styles_submit($form, &$form_state) {
  * Map preview form handler.
  */
 function openlayers_map_form_preview($form, &$form_state) {
-  $map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item']);
-  $form['preview'] = $map->build();
-
+  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
+    $form['preview'] = $map->build();
+  }
   return $form;
 }
 

--- a/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersObjects.php
+++ b/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersObjects.php
@@ -90,7 +90,10 @@ abstract class OpenlayersObjects extends ctools_export_ui {
 
     list($plugin_manager, $plugin_id) = explode(':', $item->factory_service);
     list($module, $plugin_type) = explode('.', $plugin_manager);
-    $object = \Drupal\openlayers\Openlayers::load($plugin_type, $item->machine_name);
+    $count_parents = 0;
+    if ($object = \Drupal\openlayers\Openlayers::load($plugin_type, $item->machine_name)) {
+      $count_parents = count($object->getParents());
+    }
 
     // Note: $item->{$schema['export']['export type string']} should have
     // already been set up by export.inc so we can use it safely.
@@ -125,7 +128,7 @@ abstract class OpenlayersObjects extends ctools_export_ui {
     }
     $this->rows[$name]['data'][] = array('data' => check_plain($name), 'class' => array('ctools-export-ui-name'));
     $this->rows[$name]['data'][] = array('data' => check_plain($item->factory_service), 'class' => array('ctools-export-ui-service'));
-    $this->rows[$name]['data'][] = array('data' => check_plain(count($object->getParents())), 'class' => array('ctools-export-ui-parents'));
+    $this->rows[$name]['data'][] = array('data' => check_plain($count_parents), 'class' => array('ctools-export-ui-parents'));
     $this->rows[$name]['data'][] = array('data' => check_plain($item->{$schema['export']['export type string']}), 'class' => array('ctools-export-ui-storage'));
 
     $ops = theme('links__ctools_dropbutton', array(

--- a/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersSources.inc
+++ b/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersSources.inc
@@ -77,7 +77,7 @@ function openlayers_source_form_start($form, &$form_state) {
 
   $options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Layer') as $machine_name => $layer) {
-    if (property_exists($layer, 'disabled') && ($layer->disabled == 1 || $layer->disabled == TRUE)) {
+    if (!$layer || (property_exists($layer, 'disabled') && ($layer->disabled == 1 || $layer->disabled == TRUE))) {
       continue;
     }
     $options[$machine_name] = $layer->name;
@@ -160,9 +160,10 @@ function openlayers_source_form_type_submit($form, &$form_state) {
  * Source options config form handler.
  */
 function openlayers_source_form_options($form, &$form_state) {
-  $source = \Drupal\openlayers\Openlayers::load('Source', $form_state['item']);
-  $source->optionsForm($form, $form_state);
-  $form['options']['#tree'] = TRUE;
+  if ($source = \Drupal\openlayers\Openlayers::load('Source', $form_state['item'])) {
+    $source->optionsForm($form, $form_state);
+    $form['options']['#tree'] = TRUE;
+  }
 
   return $form;
 }
@@ -171,8 +172,9 @@ function openlayers_source_form_options($form, &$form_state) {
  * Source options config form validation handler.
  */
 function openlayers_source_form_options_validate($form, &$form_state) {
-  $source = \Drupal\openlayers\Openlayers::load('Source', $form_state['item']);
-  $source->optionsFormValidate($form, $form_state);
+  if ($source = \Drupal\openlayers\Openlayers::load('Source', $form_state['item'])) {
+    $source->optionsFormValidate($form, $form_state);
+  }
 }
 
 /**
@@ -183,14 +185,15 @@ function openlayers_source_form_options_submit($form, &$form_state) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
 
-  if (!empty($form_state['item']->attachToLayer)) {
-    $layer = \Drupal\openlayers\Openlayers::load('layer', $form_state['item']->attachToLayer);
-    // We should add the object to the Collection so JS and CSS files are imported.
+  if (!empty($form_state['item']->attachToLayer) && $layer = \Drupal\openlayers\Openlayers::load('layer', $form_state['item']->attachToLayer)) {
+    // We should add the object to the Collection so JS and CSS files are
+    // imported.
     $layer->setOption('source', $form_state['item']->machine_name);
     \Drupal\openlayers\Openlayers::save($layer);
     unset($form_state['item']->attachToLayer);
   }
 
-  $source = \Drupal\openlayers\Openlayers::load('Source', $form_state['item']);
-  $source->optionsFormSubmit($form, $form_state);
+  if ($source = \Drupal\openlayers\Openlayers::load('Source', $form_state['item'])) {
+    $source->optionsFormSubmit($form, $form_state);
+  }
 }

--- a/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersStyles.inc
+++ b/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersStyles.inc
@@ -128,9 +128,10 @@ function openlayers_style_form_type_submit($form, &$form_state) {
  * Style options config form handler.
  */
 function openlayers_style_form_options($form, &$form_state) {
-  $style = \Drupal\openlayers\Openlayers::load('Style', $form_state['item']);
-  $style->optionsForm($form, $form_state);
-  $form['options']['#tree'] = TRUE;
+  if ($style = \Drupal\openlayers\Openlayers::load('Style', $form_state['item'])) {
+    $style->optionsForm($form, $form_state);
+    $form['options']['#tree'] = TRUE;
+  }
 
   return $form;
 }
@@ -139,8 +140,9 @@ function openlayers_style_form_options($form, &$form_state) {
  * Style options config form validation handler.
  */
 function openlayers_style_form_options_validate($form, &$form_state) {
-  $style = \Drupal\openlayers\Openlayers::load('Style', $form_state['item']);
-  $style->optionsFormValidate($form, $form_state);
+  if ($style = \Drupal\openlayers\Openlayers::load('Style', $form_state['item'])) {
+    $style->optionsFormValidate($form, $form_state);
+  }
 }
 
 /**
@@ -150,6 +152,7 @@ function openlayers_style_form_options_submit($form, &$form_state) {
   if (isset($form_state['values']['options'])) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
-  $style = \Drupal\openlayers\Openlayers::load('Style', $form_state['item']);
-  $style->optionsFormSubmit($form, $form_state);
+  if ($style = \Drupal\openlayers\Openlayers::load('Style', $form_state['item'])) {
+    $style->optionsFormSubmit($form, $form_state);
+  }
 }

--- a/openlayers.module
+++ b/openlayers.module
@@ -205,8 +205,9 @@ function openlayers_element_info() {
  */
 function openlayers_element_process_callback($element, $form_state, $complete_form) {
   /* @var \Drupal\openlayers\Types\Map $map */
-  $map = \Drupal\openlayers\Openlayers::load('Map', $element['#map']);
-  $element['map'] = $map->build();
+  if ($map = \Drupal\openlayers\Openlayers::load('Map', $element['#map'])) {
+    $element['map'] = $map->build();
+  }
 
   return $element;
 }
@@ -217,8 +218,9 @@ function openlayers_element_process_callback($element, $form_state, $complete_fo
 function openlayers_element_prerender_callback($element) {
   if (empty($element['map'])) {
     /* @var \Drupal\openlayers\Types\Map $map */
-    $map = \Drupal\openlayers\Openlayers::load('Map', $element['#map']);
-    $element['map'] = $map->build();
+    if ($map = \Drupal\openlayers\Openlayers::load('Map', $element['#map'])) {
+      $element['map'] = $map->build();
+    }
   }
 
   return $element;

--- a/src/Openlayers.php
+++ b/src/Openlayers.php
@@ -47,7 +47,9 @@ class Openlayers {
     $options = array();
     $type = drupal_ucfirst(drupal_strtolower($type));
     foreach (Openlayers::loadAllExportable($type) as $machine_name => $data) {
-      $options[$machine_name] = $data->name;
+      if ($data) {
+        $options[$machine_name] = $data->name;
+      }
     }
     return $options;
   }
@@ -119,6 +121,11 @@ class Openlayers {
     }
 
     if (is_array($configuration) && isset($configuration['factory_service'])) {
+      // Bail out if the base service can't be found - likely due a registry
+      // rebuild.
+      if (!\Drupal::hasService('openlayers.Types')) {
+        return NULL;
+      }
       list($plugin_manager_id, $plugin_id) = explode(':', $configuration['factory_service'], 2);
       if (\Drupal::hasService($plugin_manager_id)) {
         $plugin_manager = \Drupal::service($plugin_manager_id);
@@ -167,8 +174,10 @@ class Openlayers {
    */
   public static function loadAll($object_type = NULL) {
     $objects = array();
-    foreach(Openlayers::loadAllExportable($object_type) as $exportable) {
-      $objects[$exportable->machine_name] = Openlayers::load($object_type, $exportable);
+    foreach (Openlayers::loadAllExportable($object_type) as $exportable) {
+      if ($exportable) {
+        $objects[$exportable->machine_name] = Openlayers::load($object_type, $exportable);
+      }
     }
     return $objects;
   }

--- a/src/Plugin/Control/LayerSwitcher/LayerSwitcher.php
+++ b/src/Plugin/Control/LayerSwitcher/LayerSwitcher.php
@@ -51,16 +51,17 @@ class LayerSwitcher extends Control {
 
     $labels = $this->getOption('layer_labels', array());
     foreach ((array) $this->getOption('layers') as $i => $machine_name) {
-      $map_layer = Openlayers::load('Layer', $machine_name);
-      $label = check_plain($map_layer->name);
-      if (isset($labels[$machine_name])) {
-        $label = $labels[$machine_name];
+      if ($map_layer = Openlayers::load('Layer', $machine_name)) {
+        $label = check_plain($map_layer->name);
+        if (isset($labels[$machine_name])) {
+          $label = $labels[$machine_name];
+        }
+        $form['options']['layer_labels'][$machine_name] = array(
+          '#type' => 'textfield',
+          '#title' => t('Label for layer @label:', array('@label' => $map_layer->name)),
+          '#default_value' => $label,
+        );
       }
-      $form['options']['layer_labels'][$machine_name] = array(
-        '#type' => 'textfield',
-        '#title' => t('Label for layer @label:', array('@label' => $map_layer->name)),
-        '#default_value' => $label,
-      );
     }
     // @TODO Add configuration for initial visibility. (Adjust JS accordingly)
     // @TODO Add configuration for ordering?

--- a/src/Plugin/Map/OLMap/OLMap.php
+++ b/src/Plugin/Map/OLMap/OLMap.php
@@ -49,22 +49,23 @@ class OLMap extends Map {
     );
 
     if ($this->machine_name != Config::get('openlayers.edit_view_map')) {
-      $map = Openlayers::load('Map', Config::get('openlayers.edit_view_map'));
-      if ($view = $this->getOption('view')) {
-        // Don't apply min / max zoom settings to this map to avoid lock-in.
-        $view['minZoom'] = 0;
-        $view['maxZoom'] = 0;
-        // Same goes for limit extent.
-        $view['limit_extent'] = 0;
+      if ($map = Openlayers::load('Map', Config::get('openlayers.edit_view_map'))) {
+        if ($view = $this->getOption('view')) {
+          // Don't apply min / max zoom settings to this map to avoid lock-in.
+          $view['minZoom'] = 0;
+          $view['maxZoom'] = 0;
+          // Same goes for limit extent.
+          $view['limit_extent'] = 0;
 
-        $map->setOption('view', $view);
+          $map->setOption('view', $view);
+        }
+
+        $form['options']['view']['map'] = array(
+          '#type' => 'openlayers',
+          '#description' => $map->description,
+          '#map' => $map,
+        );
       }
-
-      $form['options']['view']['map'] = array(
-        '#type' => 'openlayers',
-        '#description' => $map->description,
-        '#map' => $map,
-      );
     }
 
     $form['options']['view']['center'] = array(

--- a/src/Types/Object.php
+++ b/src/Types/Object.php
@@ -339,9 +339,11 @@ abstract class Object extends PluginBase implements ObjectInterface {
     $parents = array();
 
     foreach (Openlayers::loadAll('Map') as $map) {
-      foreach ($map->getCollection()->getFlatList() as $object) {
-        if ($object->machine_name == $this->machine_name) {
-          $parents[$map->machine_name] = $map;
+      if ($map) {
+        foreach ($map->getCollection()->getFlatList() as $object) {
+          if ($object->machine_name == $this->machine_name) {
+            $parents[$map->machine_name] = $map;
+          }
         }
       }
     }


### PR DESCRIPTION
I just updated another page to latest service_container / openlayers.
During the process a registry rebuild is necessary in order to have all required classes ready.
Unfortunately `Openlayers::load()` doesn't check yet  if the service `openlayers.Types` is available. Leading to a fatal error in `Drupal::get()`.
I've added a check now, but a missing `openlayers.Types` also means we can't return the class for error handling - which would prevent subsequent errors due to not returning an object.
To make openlayers truly defensive we now need to check if a load operation effectively returned an object. 
I've done this now, and was able to run a registry rebuild and then the update :)