### PR TITLE
Updated the conditions since the typecasting sometimes seems to fail

### DIFF
--- a/modules/openlayers_block/openlayers_block.module
+++ b/modules/openlayers_block/openlayers_block.module
@@ -7,7 +7,7 @@ function openlayers_block_block_info() {
   $blocks = array();
 
   foreach (\Drupal\openlayers\Openlayers::loadAll('Map') as $map) {
-    if ($map && $map->getOption('provideBlock', FALSE)) {
+    if (is_object($map) && $map->getOption('provideBlock', FALSE)) {
       $key = _openlayers_block_get_block_id($map->machine_name);
       $blocks[$key]['info'] = t('OpenLayers block for @map_name', array('@map_name' => $map->name));
     }
@@ -24,11 +24,9 @@ function openlayers_block_block_view($delta = '') {
   $machine_name = _openlayers_block_get_map_name($delta);
 
   try {
-    if ($map = \Drupal\openlayers\Openlayers::load('Map', $machine_name)) {
-      if ($map->getOption('provideBlock', 1)) {
-        $block['subject'] = $map->machine_name;
-        $block['content'] = $map->build();
-      }
+    if (($map = \Drupal\openlayers\Openlayers::load('Map', $machine_name)) == TRUE && $map->getOption('provideBlock', 1)) {
+      $block['subject'] = $map->machine_name;
+      $block['content'] = $map->build();
     }
   }
   catch (Exception $e) {
@@ -62,7 +60,7 @@ function _openlayers_block_get_block_id($map_machine_name) {
  */
 function _openlayers_block_get_map_name($delta) {
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Map') as $map) {
-    if ($map && _openlayers_block_get_block_id($map->machine_name) == $delta) {
+    if (is_object($map) && _openlayers_block_get_block_id($map->machine_name) == $delta) {
       return $map->machine_name;
     }
   }
@@ -70,7 +68,7 @@ function _openlayers_block_get_map_name($delta) {
 }
 
 function openlayers_block_form_openlayers_map_form_settings_alter(&$form, &$form_state) {
-  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
+  if (($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) == TRUE) {
     $form['options']['ui']['provideBlock'] = array(
       '#type' => 'checkbox',
       '#title' => 'Provide Drupal block for this map ?',

--- a/modules/openlayers_block_switcher/openlayers_block_switcher.module
+++ b/modules/openlayers_block_switcher/openlayers_block_switcher.module
@@ -25,7 +25,7 @@ function openlayers_block_switcher_block_info() {
 function openlayers_block_switcher_block_view($delta = '') {
   $block = array();
   /** @var \Drupal\openlayers\Plugin\Map\OLMap\OLMap $map */
-  if ($map = \Drupal\openlayers\Openlayers::load('Map', _olebs_get_map_name($delta))) {
+  if (($map = \Drupal\openlayers\Openlayers::load('Map', _olebs_get_map_name($delta))) == TRUE) {
     $block['subject'] = $map->name;
     $form = drupal_get_form('olebs_blockswitcher_form', $map);
     $block['content'] = drupal_render($form);
@@ -46,8 +46,8 @@ function _olebs_get_maps_with_blockswitcher() {
   $maps = &drupal_static(__FUNCTION__, array());
 
   if (!isset($maps)) {
-    foreach(\Drupal\openlayers\Openlayers::loadAll('Map') as $map) {
-      if ($map && $map->getOption('provideBlockLayerSwitcher', FALSE) == TRUE) {
+    foreach (\Drupal\openlayers\Openlayers::loadAll('Map') as $map) {
+      if (is_object($map) && $map->getOption('provideBlockLayerSwitcher', FALSE) == TRUE) {
         $maps[] = $map;
       }
     }
@@ -131,7 +131,7 @@ function olebs_blockswitcher_form($form, &$form_state, $map) {
 }
 
 function openlayers_block_switcher_form_openlayers_map_form_settings_alter(&$form, &$form_state) {
-  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
+  if (($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) == TRUE) {
     $form['options']['ui']['provideBlockLayerSwitcher'] = array(
       '#type' => 'checkbox',
       '#title' => 'Provide Drupal block layer switcher',

--- a/modules/openlayers_content_types/plugins/content_types/openlayers.inc
+++ b/modules/openlayers_content_types/plugins/content_types/openlayers.inc
@@ -75,7 +75,7 @@ function openlayers_content_types_openlayers_content_type_admin_info($subtype, $
   $map_name = t('Unknown');
   try {
     /** @var Drupal\openlayers\Types\Map $map */
-    if ($map = \Drupal\openlayers\Openlayers::load('Map', $conf['map'])) {
+    if (($map = \Drupal\openlayers\Openlayers::load('Map', $conf['map'])) == TRUE) {
       $map_name = $map->name;
     }
   }

--- a/modules/openlayers_contextual_links/openlayers_contextual_links.module
+++ b/modules/openlayers_contextual_links/openlayers_contextual_links.module
@@ -74,7 +74,7 @@ function openlayers_contextual_links_openlayers_object_postprocess_alter(&$build
 }
 
 function openlayers_contextual_links_form_openlayers_map_form_settings_alter(&$form, &$form_state) {
-  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
+  if (($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) == TRUE) {
 
     $form['options']['ui']['contextualLinks'] = array(
       '#type' => 'checkbox',

--- a/modules/openlayers_examples/openlayers_examples.module
+++ b/modules/openlayers_examples/openlayers_examples.module
@@ -39,7 +39,7 @@ function openlayers_examples($form, &$form_state, $map_arg = NULL) {
   $maps = array();
   $options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Map') as $machine_name => $data) {
-    if (!$data || (property_exists($data, 'disabled') && ($data->disabled == 1 || $data->disabled == TRUE))) {
+    if (!is_object($data) || (property_exists($data, 'disabled') && ($data->disabled == 1 || $data->disabled == TRUE))) {
       continue;
     }
     $options[$machine_name] = $data->name;
@@ -83,7 +83,7 @@ function openlayers_examples($form, &$form_state, $map_arg = NULL) {
   );
 
   foreach ($maps as $map) {
-    if (!($map = \Drupal\openlayers\Openlayers::load('Map', $map))) {
+    if (($map = \Drupal\openlayers\Openlayers::load('Map', $map)) == FALSE) {
       continue;
     }
 

--- a/modules/openlayers_geofield/openlayers_geofield.module
+++ b/modules/openlayers_geofield/openlayers_geofield.module
@@ -53,7 +53,7 @@ function openlayers_geofield_field_formatter_settings_form($field, $instance, $v
   // Get preset options, filtered to those which have the GeoField source.
   $map_options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAll('Map') as $machine_name => $map) {
-    if ($map) {
+    if (is_object($map)) {
       foreach ($map->getObjects('source') as $source) {
         // TODO: add getSource() to Object and Object Interface.
         if ($source instanceof \Drupal\openlayers_geofield\Plugin\Source\Geofield\Geofield) {
@@ -113,7 +113,7 @@ function openlayers_geofield_field_formatter_settings_summary($field, $instance,
   }
 
   if ($display['type'] == 'openlayers_geofield' && !empty($settings['map_preset'])) {
-    if ($map = \Drupal\openlayers\Openlayers::load('Map', $settings['map_preset'])) {
+    if (($map = \Drupal\openlayers\Openlayers::load('Map', $settings['map_preset'])) == TRUE) {
       $summary[] = t('Openlayers Map: @data', array('@data' => $map->name));
     }
   }
@@ -204,7 +204,7 @@ function openlayers_geofield_field_formatter_view($entity_type, $entity, $field,
 
   // Load map and set features.
   $map_name = $display['settings']['map_preset'] ? $display['settings']['map_preset'] : 'openlayers_geofield_map_geofield_formatter';
-  if ($map = \Drupal\openlayers\Openlayers::load('Map', $map_name)) {
+  if (($map = \Drupal\openlayers\Openlayers::load('Map', $map_name)) == TRUE) {
     $geofield_source = NULL;
     foreach ($map->getObjects('source') as $source) {
       if ($source instanceof \Drupal\openlayers_geofield\Plugin\Source\Geofield\Geofield) {
@@ -265,7 +265,7 @@ function openlayers_geofield_field_widget_settings_form($field, $instance) {
   $maps = \Drupal\openlayers\Openlayers::loadAll('Map');
   $map_options = array();
   foreach ($maps as $machine_name => $map) {
-    if ($map) {
+    if (is_object($map)) {
       foreach ($map->getObjects('component') as $component) {
         if ($component instanceof \Drupal\openlayers_geofield\Plugin\Component\Geofield\Geofield) {
           $map_options[$machine_name] = $map->name;
@@ -392,7 +392,7 @@ function openlayers_geofield_field_widget_form(&$form, &$form_state, $field, $in
 
   $openlayers_map_id = !empty($instance['widget']['settings']['openlayers_map']) ? $instance['widget']['settings']['openlayers_map'] : 'openlayers_geofield_map_geofield';
 
-  if (!($map = \Drupal\openlayers\Openlayers::load('Map', $openlayers_map_id))) {
+  if (($map = \Drupal\openlayers\Openlayers::load('Map', $openlayers_map_id)) == FALSE) {
     // If the map couldn't be load we can't do a thing.
     return NULL;
   }

--- a/modules/openlayers_services/openlayers_services.helpers.inc
+++ b/modules/openlayers_services/openlayers_services.helpers.inc
@@ -5,7 +5,7 @@
  */
 
 function _openlayers_services_retrieve($name) {
-  if ($map = \Drupal\openlayers\Openlayers::load('Map', $name)) {
+  if (($map = \Drupal\openlayers\Openlayers::load('Map', $name)) == TRUE) {
     $build = $map->build();
     $render = drupal_render($build);
     $js = drupal_get_js();
@@ -21,5 +21,5 @@ function _openlayers_services_retrieve($name) {
 
 function _openlayers_services_access($operation, $map) {
   $map = \Drupal\openlayers\Openlayers::load('Map', $map[0]);
-  return $map && (bool) $map->getOption('provideIframe', FALSE);
+  return $map == TRUE && (bool) $map->getOption('provideIframe', FALSE);
 }

--- a/modules/openlayers_services/openlayers_services.module
+++ b/modules/openlayers_services/openlayers_services.module
@@ -64,7 +64,7 @@ function openlayers_services_theme($existing, $type, $theme, $path) {
 }
 
 function openlayers_services_form_openlayers_map_form_settings_alter(&$form, &$form_state) {
-  if ($map = \Drupal\openlayers\Openlayers::load('map', $form_state['item'])) {
+  if (($map = \Drupal\openlayers\Openlayers::load('map', $form_state['item'])) == TRUE) {
 
     $form['options']['ui']['provideIframe'] = array(
       '#type' => 'checkbox',
@@ -79,7 +79,7 @@ function openlayers_services_form_openlayers_map_form_settings_alter(&$form, &$f
 function openlayers_services_form_openlayers_map_form_preview_alter(&$form, &$form_state) {
   $map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']);
 
-  if (!$map || (bool) $map->getOption('provideIframe', FALSE) == FALSE) {
+  if ($map == FALSE || (bool) $map->getOption('provideIframe', FALSE) == FALSE) {
     return;
   }
 

--- a/modules/openlayers_ui/includes/openlayers_ui.admin.inc
+++ b/modules/openlayers_ui/includes/openlayers_ui.admin.inc
@@ -14,7 +14,7 @@
 function openlayers_ui_admin_settings($form, &$form_state) {
   $options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Map') as $machine_name => $data) {
-    if (!$data || (property_exists($data, 'disabled') && ($data->disabled == 1 || $data->disabled == TRUE))) {
+    if (!is_object($data) || (property_exists($data, 'disabled') && ($data->disabled == 1 || $data->disabled == TRUE))) {
       continue;
     }
     $options[$machine_name] = $data->name;

--- a/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersComponents.inc
+++ b/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersComponents.inc
@@ -77,7 +77,7 @@ function openlayers_component_form_start($form, &$form_state) {
 
   $options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Map') as $machine_name => $map) {
-    if (!$map || (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE))) {
+    if (!is_object($map) || (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE))) {
       continue;
     }
     $options[$machine_name] = $map->name;
@@ -141,7 +141,7 @@ function openlayers_component_form_type_submit($form, &$form_state) {
  * Component options form handler.
  */
 function openlayers_component_form_options($form, &$form_state) {
-  if ($component = \Drupal\openlayers\Openlayers::load('Component', $form_state['item'])) {
+  if (($component = \Drupal\openlayers\Openlayers::load('Component', $form_state['item'])) == TRUE) {
     $component->optionsForm($form, $form_state);
     $form['options']['#tree'] = TRUE;
   }
@@ -153,7 +153,7 @@ function openlayers_component_form_options($form, &$form_state) {
  * Component options form validation handler.
  */
 function openlayers_component_form_options_validate($form, &$form_state) {
-  if ($component = \Drupal\openlayers\Openlayers::load('Component', $form_state['item'])) {
+  if (($component = \Drupal\openlayers\Openlayers::load('Component', $form_state['item'])) == TRUE) {
     $component->optionsFormValidate($form, $form_state);
   }
 }
@@ -166,8 +166,8 @@ function openlayers_component_form_options_submit($form, &$form_state) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
 
-  if ($component = \Drupal\openlayers\Openlayers::load('Component', $form_state['item'])) {
-    if (!empty($form_state['item']->attachToMap) && ($map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap))) {
+  if (($component = \Drupal\openlayers\Openlayers::load('Component', $form_state['item'])) == TRUE) {
+    if (!empty($form_state['item']->attachToMap) && ($map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap)) == TRUE) {
       $map->getCollection()->append($component);
       \Drupal\openlayers\Openlayers::save($map);
       unset($form_state['item']->attachToMap);

--- a/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersControls.inc
+++ b/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersControls.inc
@@ -77,7 +77,7 @@ function openlayers_control_form_start($form, &$form_state) {
 
   $options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Map') as $machine_name => $map) {
-    if (!$map || (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE))) {
+    if (!is_object($map) || (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE))) {
       continue;
     }
     $options[$machine_name] = $map->name;
@@ -141,7 +141,7 @@ function openlayers_control_form_type_submit($form, &$form_state) {
  * Control options config form handler.
  */
 function openlayers_control_form_options($form, &$form_state) {
-  if ($control = \Drupal\openlayers\Openlayers::load('Control', $form_state['item'])) {
+  if (($control = \Drupal\openlayers\Openlayers::load('Control', $form_state['item'])) == TRUE) {
     $control->optionsForm($form, $form_state);
     $form['options']['#tree'] = TRUE;
   }
@@ -153,7 +153,7 @@ function openlayers_control_form_options($form, &$form_state) {
  * Control options config form validation handler.
  */
 function openlayers_control_form_options_validate($form, &$form_state) {
-  if ($control = \Drupal\openlayers\Openlayers::load('Control', $form_state['item'])) {
+  if (($control = \Drupal\openlayers\Openlayers::load('Control', $form_state['item'])) == TRUE) {
     $control->optionsFormValidate($form, $form_state);
   }
 }
@@ -166,8 +166,8 @@ function openlayers_control_form_options_submit($form, &$form_state) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
 
-  if ($control = \Drupal\openlayers\Openlayers::load('Control', $form_state['item'])) {
-    if (!empty($form_state['item']->attachToMap) && $map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap)) {
+  if (($control = \Drupal\openlayers\Openlayers::load('Control', $form_state['item'])) == TRUE) {
+    if (!empty($form_state['item']->attachToMap) && ($map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap)) == TRUE) {
       $map->getCollection()->append($control);
       \Drupal\openlayers\Openlayers::save($map);
       unset($form_state['item']->attachToMap);

--- a/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersInteractions.inc
+++ b/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersInteractions.inc
@@ -77,7 +77,7 @@ function openlayers_interaction_form_start($form, &$form_state) {
 
   $options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Map') as $machine_name => $map) {
-    if (!$map || (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE))) {
+    if (!is_object($map) || (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE))) {
       continue;
     }
     $options[$machine_name] = $map->name;
@@ -141,7 +141,7 @@ function openlayers_interaction_form_type_submit($form, &$form_state) {
  * Interaction options config form handler.
  */
 function openlayers_interaction_form_options($form, &$form_state) {
-  if ($interaction = \Drupal\openlayers\Openlayers::load('Interaction', $form_state['item'])) {
+  if (($interaction = \Drupal\openlayers\Openlayers::load('Interaction', $form_state['item'])) == TRUE) {
     $interaction->optionsForm($form, $form_state);
     $form['options']['#tree'] = TRUE;
   }
@@ -153,7 +153,7 @@ function openlayers_interaction_form_options($form, &$form_state) {
  * Interaction options config form validation handler.
  */
 function openlayers_interaction_form_options_validate($form, &$form_state) {
-  if ($interaction = \Drupal\openlayers\Openlayers::load('Interaction', $form_state['item'])) {
+  if (($interaction = \Drupal\openlayers\Openlayers::load('Interaction', $form_state['item'])) == TRUE) {
     $interaction->optionsFormValidate($form, $form_state);
   }
 }
@@ -166,8 +166,8 @@ function openlayers_interaction_form_options_submit($form, &$form_state) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
 
-  if ($interaction = \Drupal\openlayers\Openlayers::load('Interaction', $form_state['item'])) {
-    if (!empty($form_state['item']->attachToMap) && $map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap)) {
+  if (($interaction = \Drupal\openlayers\Openlayers::load('Interaction', $form_state['item'])) == TRUE) {
+    if (!empty($form_state['item']->attachToMap) && ($map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap)) == TRUE) {
       $map->getCollection()->append($interaction);
       \Drupal\openlayers\Openlayers::save($map);
       unset($form_state['item']->attachToMap);

--- a/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersLayers.inc
+++ b/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersLayers.inc
@@ -81,7 +81,7 @@ function openlayers_layer_form_start($form, &$form_state) {
 
   $options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Map') as $machine_name => $map) {
-    if (!$map || (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE))) {
+    if (!is_object($map) || (property_exists($map, 'disabled') && ($map->disabled == 1 || $map->disabled == TRUE))) {
       continue;
     }
     $options[$machine_name] = $map->name;
@@ -199,7 +199,7 @@ function openlayers_layer_form_style_submit($form, &$form_state) {
  * Layer options config form handler.
  */
 function openlayers_layer_form_options($form, &$form_state) {
-  if ($layer = \Drupal\openlayers\Openlayers::load('Layer', $form_state['item'])) {
+  if (($layer = \Drupal\openlayers\Openlayers::load('Layer', $form_state['item'])) == TRUE) {
     $layer->optionsForm($form, $form_state);
     $form['options']['#tree'] = TRUE;
   }
@@ -211,7 +211,7 @@ function openlayers_layer_form_options($form, &$form_state) {
  * Layer options config form validation handler.
  */
 function openlayers_layer_form_options_validate($form, &$form_state) {
-  if ($layer = \Drupal\openlayers\Openlayers::load('Layer', $form_state['item'])) {
+  if (($layer = \Drupal\openlayers\Openlayers::load('Layer', $form_state['item'])) == TRUE) {
     $layer->optionsFormValidate($form, $form_state);
   }
 }
@@ -224,8 +224,8 @@ function openlayers_layer_form_options_submit($form, &$form_state) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
 
-  if ($layer = \Drupal\openlayers\Openlayers::load('Layer', $form_state['item'])) {
-    if (!empty($form_state['item']->attachToMap) && $map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap)) {
+  if (($layer = \Drupal\openlayers\Openlayers::load('Layer', $form_state['item'])) == TRUE) {
+    if (!empty($form_state['item']->attachToMap) && ($map = \Drupal\openlayers\Openlayers::load('map', $form_state['item']->attachToMap)) == TRUE) {
       $map->getCollection()->append($layer);
       \Drupal\openlayers\Openlayers::save($map);
       unset($form_state['item']->attachToMap);

--- a/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersMaps.inc
+++ b/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersMaps.inc
@@ -122,7 +122,7 @@ function openlayers_map_form_settings($form, &$form_state) {
   if (!isset($form_state['item']->factory_service)) {
     $form_state['item']->factory_service = 'openlayers.Map:OLMap';
   }
-  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
+  if (($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) == TRUE) {
     $map->optionsForm($form, $form_state);
     $form['options']['#tree'] = TRUE;
   }
@@ -142,7 +142,7 @@ function openlayers_map_form_settings_validate($form, &$form_state) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
 
-  if ($map = \Drupal\openlayers\Openlayers::load('Map', $item)) {
+  if (($map = \Drupal\openlayers\Openlayers::load('Map', $item)) == TRUE) {
     $map->optionsFormValidate($form, $form_state);
   }
 }
@@ -159,7 +159,7 @@ function openlayers_map_form_settings_submit($form, &$form_state) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
 
-  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
+  if (($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) == TRUE) {
     $map->optionsFormSubmit($form, $form_state);
   }
 }
@@ -169,13 +169,13 @@ function openlayers_map_form_settings_submit($form, &$form_state) {
  */
 function openlayers_map_form_layers($form, &$form_state) {
   $all_layers = \Drupal\openlayers\Openlayers::loadAllExportable('Layer');
-  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
+  if (($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) == FALSE) {
     return;
   }
 
   $layers = array();
   foreach ($map->getObjects('layer') as $layer) {
-    if (isset($all_layers[$layer->machine_name])) {
+    if (is_object($layer) && isset($all_layers[$layer->machine_name])) {
       $layers[$layer->machine_name] = $all_layers[$layer->machine_name];
       $layers[$layer->machine_name]->enable = 1;
       unset($all_layers[$layer->machine_name]);
@@ -189,7 +189,7 @@ function openlayers_map_form_layers($form, &$form_state) {
   $i = 0;
   /* @var \Drupal\openlayers\Types\Layer $layer */
   foreach ($layers as $machine_name => $layer) {
-    if ($layer) {
+    if (is_object($layer)) {
       $data[$machine_name] = array(
         'name' => $layer->name,
         'machine_name' => $layer->machine_name,
@@ -299,7 +299,7 @@ function openlayers_map_form_layers($form, &$form_state) {
 
   $sources = array();
   /* @var \Drupal\openlayers\Types\Map $map */
-  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
+  if (($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) == TRUE) {
     foreach ($map->getObjects('source') as $source) {
       if (isset($all_sources[$source->machine_name])) {
         $sources[$source->machine_name] = $all_sources[$source->machine_name];
@@ -315,7 +315,7 @@ function openlayers_map_form_layers($form, &$form_state) {
 
   $i = 0;
   foreach ($sources as $machine_name => $source) {
-    if ($source) {
+    if (is_object($source)) {
       $data[$machine_name] = array(
         'name' => $source->name,
         'machine_name' => $source->machine_name,
@@ -415,7 +415,7 @@ function openlayers_map_form_layers_submit($form, &$form_state) {
       $layers_enabled[$data['weight']] = $id;
 
       //Update the layer style.
-      if ($layer = \Drupal\openlayers\Openlayers::load('layer', $data['machine_name'])) {
+      if (($layer = \Drupal\openlayers\Openlayers::load('layer', $data['machine_name'])) == TRUE) {
         if (!is_null($data['style'])) {
           if ($data['style'] != $layer->getOption('style')) {
             $layer->setOption('style', $data['style']);
@@ -468,7 +468,7 @@ function openlayers_map_form_controls($form, &$form_state) {
 
   $i = 0;
   foreach ($all_controls as $machine_name => $control) {
-    if ($control) {
+    if (is_object($control)) {
       $data[$machine_name] = array(
         'name' => $control->name,
         'machine_name' => $control->machine_name,
@@ -590,7 +590,7 @@ function openlayers_map_form_interactions($form, &$form_state) {
 
   $rows = array();
   foreach ($all_interactions as $machine_name => $interaction) {
-    if ($interaction) {
+    if (is_object($interaction)) {
       $rows[$machine_name] = array(
         'name' => $interaction->name,
         'machine_name' => $interaction->machine_name,
@@ -656,7 +656,7 @@ function openlayers_map_form_components($form, &$form_state) {
 
   $i = 0;
   foreach ($all_components as $machine_name => $component) {
-    if ($component) {
+    if (is_object($component)) {
       $data[$machine_name] = array(
         'name' => $component->name,
         'machine_name' => $component->machine_name,
@@ -777,7 +777,7 @@ function openlayers_map_form_styles_submit($form, &$form_state) {
  * Map preview form handler.
  */
 function openlayers_map_form_preview($form, &$form_state) {
-  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
+  if (($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) == TRUE) {
     $form['preview'] = $map->build();
   }
   return $form;

--- a/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersSources.inc
+++ b/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersSources.inc
@@ -77,7 +77,7 @@ function openlayers_source_form_start($form, &$form_state) {
 
   $options = array();
   foreach (\Drupal\openlayers\Openlayers::loadAllExportable('Layer') as $machine_name => $layer) {
-    if (!$layer || (property_exists($layer, 'disabled') && ($layer->disabled == 1 || $layer->disabled == TRUE))) {
+    if (!is_object($layer) || (property_exists($layer, 'disabled') && ($layer->disabled == 1 || $layer->disabled == TRUE))) {
       continue;
     }
     $options[$machine_name] = $layer->name;
@@ -160,7 +160,7 @@ function openlayers_source_form_type_submit($form, &$form_state) {
  * Source options config form handler.
  */
 function openlayers_source_form_options($form, &$form_state) {
-  if ($source = \Drupal\openlayers\Openlayers::load('Source', $form_state['item'])) {
+  if (($source = \Drupal\openlayers\Openlayers::load('Source', $form_state['item'])) == TRUE) {
     $source->optionsForm($form, $form_state);
     $form['options']['#tree'] = TRUE;
   }
@@ -172,7 +172,7 @@ function openlayers_source_form_options($form, &$form_state) {
  * Source options config form validation handler.
  */
 function openlayers_source_form_options_validate($form, &$form_state) {
-  if ($source = \Drupal\openlayers\Openlayers::load('Source', $form_state['item'])) {
+  if (($source = \Drupal\openlayers\Openlayers::load('Source', $form_state['item'])) == TRUE) {
     $source->optionsFormValidate($form, $form_state);
   }
 }
@@ -185,7 +185,7 @@ function openlayers_source_form_options_submit($form, &$form_state) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
 
-  if (!empty($form_state['item']->attachToLayer) && $layer = \Drupal\openlayers\Openlayers::load('layer', $form_state['item']->attachToLayer)) {
+  if (!empty($form_state['item']->attachToLayer) && ($layer = \Drupal\openlayers\Openlayers::load('layer', $form_state['item']->attachToLayer)) == TRUE) {
     // We should add the object to the Collection so JS and CSS files are
     // imported.
     $layer->setOption('source', $form_state['item']->machine_name);
@@ -193,7 +193,7 @@ function openlayers_source_form_options_submit($form, &$form_state) {
     unset($form_state['item']->attachToLayer);
   }
 
-  if ($source = \Drupal\openlayers\Openlayers::load('Source', $form_state['item'])) {
+  if (($source = \Drupal\openlayers\Openlayers::load('Source', $form_state['item'])) == TRUE) {
     $source->optionsFormSubmit($form, $form_state);
   }
 }

--- a/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersStyles.inc
+++ b/modules/openlayers_ui/src/Plugin/export_ui/OpenlayersStyles.inc
@@ -128,7 +128,7 @@ function openlayers_style_form_type_submit($form, &$form_state) {
  * Style options config form handler.
  */
 function openlayers_style_form_options($form, &$form_state) {
-  if ($style = \Drupal\openlayers\Openlayers::load('Style', $form_state['item'])) {
+  if (($style = \Drupal\openlayers\Openlayers::load('Style', $form_state['item'])) == TRUE) {
     $style->optionsForm($form, $form_state);
     $form['options']['#tree'] = TRUE;
   }
@@ -140,7 +140,7 @@ function openlayers_style_form_options($form, &$form_state) {
  * Style options config form validation handler.
  */
 function openlayers_style_form_options_validate($form, &$form_state) {
-  if ($style = \Drupal\openlayers\Openlayers::load('Style', $form_state['item'])) {
+  if (($style = \Drupal\openlayers\Openlayers::load('Style', $form_state['item'])) == TRUE) {
     $style->optionsFormValidate($form, $form_state);
   }
 }
@@ -152,7 +152,7 @@ function openlayers_style_form_options_submit($form, &$form_state) {
   if (isset($form_state['values']['options'])) {
     $form_state['item']->options = array_merge((array) $form_state['item']->options, (array) $form_state['values']['options']);
   }
-  if ($style = \Drupal\openlayers\Openlayers::load('Style', $form_state['item'])) {
+  if (($style = \Drupal\openlayers\Openlayers::load('Style', $form_state['item'])) == TRUE) {
     $style->optionsFormSubmit($form, $form_state);
   }
 }

--- a/modules/openlayers_views/views/openlayers_views_plugin_map_views.inc
+++ b/modules/openlayers_views/views/openlayers_views_plugin_map_views.inc
@@ -45,7 +45,7 @@ class openlayers_views_plugin_map_views extends openlayers_views_plugin_style_so
 
     $output = NULL;
     $map_machine_name = 'map_views_' . $this->view->name . '_' . $this->view->current_display;
-    if (empty($this->skipMapRender) && ($this->map = \Drupal\openlayers\Openlayers::load('Map', $map_machine_name)) && !($this->map instanceof \Drupal\openlayers\Types\Error)) {
+    if (empty($this->skipMapRender) && ($this->map = \Drupal\openlayers\Openlayers::load('Map', $map_machine_name)) == TRUE && !($this->map instanceof \Drupal\openlayers\Types\Error)) {
       // Inject the features so that the map handler doesn't execute the view
       // again.
       $this->map->setFeatures($this->features);

--- a/openlayers.module
+++ b/openlayers.module
@@ -205,7 +205,7 @@ function openlayers_element_info() {
  */
 function openlayers_element_process_callback($element, $form_state, $complete_form) {
   /* @var \Drupal\openlayers\Types\Map $map */
-  if ($map = \Drupal\openlayers\Openlayers::load('Map', $element['#map'])) {
+  if (($map = \Drupal\openlayers\Openlayers::load('Map', $element['#map'])) == TRUE) {
     $element['map'] = $map->build();
   }
 
@@ -218,7 +218,7 @@ function openlayers_element_process_callback($element, $form_state, $complete_fo
 function openlayers_element_prerender_callback($element) {
   if (empty($element['map'])) {
     /* @var \Drupal\openlayers\Types\Map $map */
-    if ($map = \Drupal\openlayers\Openlayers::load('Map', $element['#map'])) {
+    if (($map = \Drupal\openlayers\Openlayers::load('Map', $element['#map'])) == TRUE) {
       $element['map'] = $map->build();
     }
   }

--- a/src/Openlayers.php
+++ b/src/Openlayers.php
@@ -47,7 +47,7 @@ class Openlayers {
     $options = array();
     $type = drupal_ucfirst(drupal_strtolower($type));
     foreach (Openlayers::loadAllExportable($type) as $machine_name => $data) {
-      if ($data) {
+      if (is_object($data)) {
         $options[$machine_name] = $data->name;
       }
     }
@@ -175,7 +175,7 @@ class Openlayers {
   public static function loadAll($object_type = NULL) {
     $objects = array();
     foreach (Openlayers::loadAllExportable($object_type) as $exportable) {
-      if ($exportable) {
+      if (is_object($exportable)) {
         $objects[$exportable->machine_name] = Openlayers::load($object_type, $exportable);
       }
     }

--- a/src/Plugin/Control/LayerSwitcher/LayerSwitcher.php
+++ b/src/Plugin/Control/LayerSwitcher/LayerSwitcher.php
@@ -51,7 +51,7 @@ class LayerSwitcher extends Control {
 
     $labels = $this->getOption('layer_labels', array());
     foreach ((array) $this->getOption('layers') as $i => $machine_name) {
-      if ($map_layer = Openlayers::load('Layer', $machine_name)) {
+      if (($map_layer = Openlayers::load('Layer', $machine_name)) == TRUE) {
         $label = check_plain($map_layer->name);
         if (isset($labels[$machine_name])) {
           $label = $labels[$machine_name];

--- a/src/Plugin/Map/OLMap/OLMap.php
+++ b/src/Plugin/Map/OLMap/OLMap.php
@@ -49,7 +49,7 @@ class OLMap extends Map {
     );
 
     if ($this->machine_name != Config::get('openlayers.edit_view_map')) {
-      if ($map = Openlayers::load('Map', Config::get('openlayers.edit_view_map'))) {
+      if (($map = Openlayers::load('Map', Config::get('openlayers.edit_view_map'))) == TRUE) {
         if ($view = $this->getOption('view')) {
           // Don't apply min / max zoom settings to this map to avoid lock-in.
           $view['minZoom'] = 0;

--- a/src/Types/Object.php
+++ b/src/Types/Object.php
@@ -339,7 +339,7 @@ abstract class Object extends PluginBase implements ObjectInterface {
     $parents = array();
 
     foreach (Openlayers::loadAll('Map') as $map) {
-      if ($map) {
+      if (is_object($map)) {
         foreach ($map->getCollection()->getFlatList() as $object) {
           if ($object->machine_name == $this->machine_name) {
             $parents[$map->machine_name] = $map;

--- a/src/Types/Source.php
+++ b/src/Types/Source.php
@@ -16,7 +16,7 @@ abstract class Source extends Object implements SourceInterface {
    */
   public function buildCollection() {
     foreach ((array) $this->getOption('sources', array()) as $weight => $object) {
-      if ($merge_object = Openlayers::load('source', $object)) {
+      if (($merge_object = Openlayers::load('source', $object)) == TRUE) {
         $merge_object->setWeight($weight);
         $this->getCollection()->merge($merge_object->getCollection());
       }


### PR DESCRIPTION
As via chat discussed:
The new conditions have broken some of the pages.
E.g. `admin/structure/openlayers/maps/list/my_map/edit/layers`.
The code bails out here:
```php
function openlayers_map_form_layers($form, &$form_state) {
  $all_layers = \Drupal\openlayers\Openlayers::loadAllExportable('Layer');
  if ($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) {
    return;
  }
```

Even though `$map` / the return is an object and objects are casted to boolean TRUE according to http://php.net/manual/en/language.types.boolean.php:
> When converting to boolean, the following values are considered FALSE:
> ...
> an object with zero member variables (PHP 4 only)
> ..

Which actually means as of PHP 5 an object should always be TRUE.

Interestingly following code works as expected: 
```php
function openlayers_map_form_layers($form, &$form_state) {
  $all_layers = \Drupal\openlayers\Openlayers::loadAllExportable('Layer');
  if (($map = \Drupal\openlayers\Openlayers::load('Map', $form_state['item'])) == FALSE) {
    return;
  }
```

I'm not quite sure why we see this behaviour - maybe it's the assignment in the condition, but just adding parenthesis doesn't do the trick.

However, I've adjusted the code to do more "detailed" checks.