### PR TITLE
Allow LayerSwitcher parent preBuild() method to run.

### DIFF
--- a/src/Plugin/Control/LayerSwitcher/LayerSwitcher.php
+++ b/src/Plugin/Control/LayerSwitcher/LayerSwitcher.php
@@ -115,6 +115,9 @@ class LayerSwitcher extends Control {
       ),
     );
     $this->setOption('element', '<div id="' . drupal_html_id($this->machine_name) . '" class="' . drupal_html_class($this->machine_name) . ' layerswitcher">' . drupal_render($layerswitcher) . '</div>');
+
+    // Allow the parent class to perform it's pre-build actions.
+    parent::preBuild($build, $context);
   }
 
   /**


### PR DESCRIPTION
I was trying to use hook_openlayers_object_preprocess_alter() on a LayerSwitcher object, but noticed that the LayerSwitcher class overrides the parent Control::preBuild() method, but does not execute the parent's method. This means that drupal_alter() is not run on LayerSwitcher objects.