### PR TITLE
Refactoring style handling.

### DIFF
--- a/includes/openlayers.default_openlayers_interactions.inc
+++ b/includes/openlayers.default_openlayers_interactions.inc
@@ -155,7 +155,9 @@ function openlayers_default_openlayers_interactions() {
   $ol_interaction->name = 'Select';
   $ol_interaction->description = 'Select interaction description';
   $ol_interaction->factory_service = 'openlayers.Interaction:Select';
-  $ol_interaction->options = array();
+  $ol_interaction->options = array(
+    'style' => 'openlayers_style_select',
+  );
   $export['openlayers_interaction_select'] = $ol_interaction;
 
   $ol_interaction = new stdClass();

--- a/includes/openlayers.default_openlayers_styles.inc
+++ b/includes/openlayers.default_openlayers_styles.inc
@@ -13,7 +13,7 @@ function openlayers_default_openlayers_styles() {
   $ol_style = new stdClass();
   $ol_style->api_version = 1;
   $ol_style->machine_name = 'openlayers_style_default';
-  $ol_style->name = 'Openlayers default style';
+  $ol_style->name = 'Openlayers: Default';
   $ol_style->description = '';
   $ol_style->factory_service = 'openlayers.Style:Circle';
   $ol_style->options = array(
@@ -42,9 +42,73 @@ function openlayers_default_openlayers_styles() {
   $export['openlayers_style_default'] = $ol_style;
 
   $ol_style = new stdClass();
+  $ol_style->disabled = FALSE; /* Edit this to true to make a default ol_style disabled initially */
+  $ol_style->api_version = 1;
+  $ol_style->machine_name = 'openlayers_style_select';
+  $ol_style->name = 'Openlayers: Default select';
+  $ol_style->description = '';
+  $ol_style->factory_service = 'openlayers.Style:Circle';
+  $ol_style->options = array(
+    'default' => array(
+      'image' => array(
+        'radius' => 5,
+        'fill' => array(
+          'color' => '51,153,204,0.7',
+        ),
+        'stroke' => array(
+          'color' => '51,153,204,1',
+          'width' => 3,
+          'lineDash' => '0,0',
+        ),
+      ),
+      'stroke' => array(
+        'color' => '51,153,204,1',
+        'width' => 3,
+        'lineDash' => '0,0',
+      ),
+      'fill' => array(
+        'color' => '51,153,204,0.7',
+      ),
+    ),
+  );
+  $export['openlayers_style_select'] = $ol_style;
+
+  $ol_style = new stdClass();
+  $ol_style->disabled = FALSE; /* Edit this to true to make a default ol_style disabled initially */
+  $ol_style->api_version = 1;
+  $ol_style->machine_name = 'openlayers_style_drag';
+  $ol_style->name = 'Openlayers: Default drag';
+  $ol_style->description = '';
+  $ol_style->factory_service = 'openlayers.Style:Circle';
+  $ol_style->options = array(
+    'default' => array(
+      'image' => array(
+        'radius' => 5,
+        'fill' => array(
+          'color' => '255,0,0,0.7',
+        ),
+        'stroke' => array(
+          'color' => '255,0,0,1',
+          'width' => 3,
+          'lineDash' => '0,0',
+        ),
+      ),
+      'stroke' => array(
+        'color' => '255,0,0,1',
+        'width' => 3,
+        'lineDash' => '0,0',
+      ),
+      'fill' => array(
+        'color' => '255,0,0,0.7',
+      ),
+    ),
+  );
+  $export['openlayers_style_drag'] = $ol_style;
+
+  $ol_style = new stdClass();
   $ol_style->api_version = 1;
   $ol_style->machine_name = 'openlayers_style_invisible';
-  $ol_style->name = 'Openlayers style invisible';
+  $ol_style->name = 'Openlayers: Invisible';
   $ol_style->description = '';
   $ol_style->factory_service = 'openlayers.Style:Invisible';
   $export['openlayers_style_invisible'] = $ol_style;

--- a/includes/openlayers.default_openlayers_styles.inc
+++ b/includes/openlayers.default_openlayers_styles.inc
@@ -17,14 +17,27 @@ function openlayers_default_openlayers_styles() {
   $ol_style->description = '';
   $ol_style->factory_service = 'openlayers.Style:Circle';
   $ol_style->options = array(
-    'fill' => array(
-      'color' => '255, 255, 255, 0.4',
+    'default' => array(
+      'image' => array(
+        'radius' => 5,
+        'fill' => array(
+          'color' => '255,255,255,0.4',
+        ),
+        'stroke' => array(
+          'color' => '51,153,204,1',
+          'width' => 1.25,
+          'lineDash' => '0,0',
+        ),
+      ),
+      'stroke' => array(
+        'color' => '51,153,204,1',
+        'width' => 1.25,
+        'lineDash' => '0,0',
+      ),
+      'fill' => array(
+        'color' => '51,153,204,1',
+      ),
     ),
-    'stroke' => array(
-      'color' => '51, 153, 204, 1',
-      'width' => 1.25,
-    ),
-    'radius' => 5,
   );
   $export['openlayers_style_default'] = $ol_style;
 

--- a/js/openlayers.js
+++ b/js/openlayers.js
@@ -24,6 +24,14 @@ Drupal.openlayers = (function($){
         map = Drupal.openlayers.getObject(context, 'maps', settings.map, map_id);
         $(document).trigger('openlayers.map_post_alter', [{map: Drupal.openlayers.instances[map_id].map}]);
 
+        if (settings.style.length > 0) {
+          $(document).trigger('openlayers.styles_pre_alter', [{styles: settings.style, map_id: map_id}]);
+          settings.style.map(function (data) {
+            Drupal.openlayers.getObject(context, 'styles', data, map_id);
+          });
+          $(document).trigger('openlayers.styles_post_alter', [{styles: settings.style, map_id: map_id}]);
+        }
+
         if (settings.source.length > 0) {
           $(document).trigger('openlayers.sources_pre_alter', [{sources: settings.source, map_id: map_id}]);
           settings.source.map(function (data) {
@@ -48,14 +56,6 @@ Drupal.openlayers = (function($){
             }
           });
           $(document).trigger('openlayers.interactions_post_alter', [{interactions: settings.interaction, map_id: map_id}]);
-        }
-
-        if (settings.style.length > 0) {
-          $(document).trigger('openlayers.styles_pre_alter', [{styles: settings.style, map_id: map_id}]);
-          settings.style.map(function (data) {
-            Drupal.openlayers.getObject(context, 'styles', data, map_id);
-          });
-          $(document).trigger('openlayers.styles_post_alter', [{styles: settings.style, map_id: map_id}]);
         }
 
         if (settings.layer.length > 0) {

--- a/modules/openlayers_examples/includes/openlayers_examples.default_openlayers_interactions.inc
+++ b/modules/openlayers_examples/includes/openlayers_examples.default_openlayers_interactions.inc
@@ -10,5 +10,30 @@
 function openlayers_examples_default_openlayers_interactions() {
   $export = array();
 
+  $ol_interaction = new stdClass();
+  $ol_interaction->disabled = FALSE; /* Edit this to true to make a default ol_interaction disabled initially */
+  $ol_interaction->api_version = 1;
+  $ol_interaction->machine_name = 'openlayers_examples_interaction_drag_features';
+  $ol_interaction->name = 'Openlayers examples: Drag features';
+  $ol_interaction->description = 'Drag features';
+  $ol_interaction->factory_service = 'openlayers.Interaction:DragFeature';
+  $ol_interaction->options = array(
+    'style' => 'openlayers_style_drag',
+  );
+  $export['openlayers_examples_interaction_drag_features'] = $ol_interaction;
+
+  $ol_interaction = new stdClass();
+  $ol_interaction->disabled = FALSE; /* Edit this to true to make a default ol_interaction disabled initially */
+  $ol_interaction->api_version = 1;
+  $ol_interaction->machine_name = 'openlayers_examples_interaction_select';
+  $ol_interaction->name = 'Openlayers examples: Select';
+  $ol_interaction->description = '';
+  $ol_interaction->factory_service = 'openlayers.Interaction:Select';
+  $ol_interaction->options = array(
+    'style' => 'openlayers_style_select',
+    'multi' => 1,
+  );
+  $export['openlayers_examples_interaction_select'] = $ol_interaction;
+
   return $export;
 }

--- a/modules/openlayers_examples/includes/openlayers_examples.default_openlayers_layers.inc
+++ b/modules/openlayers_examples/includes/openlayers_examples.default_openlayers_layers.inc
@@ -772,5 +772,18 @@ function openlayers_examples_default_openlayers_layers() {
   );
   $export['openlayers_examples_layer_group_base'] = $ol_layer;
 
+  $ol_layer = new stdClass();
+  $ol_layer->disabled = FALSE; /* Edit this to true to make a default ol_layer disabled initially */
+  $ol_layer->api_version = 1;
+  $ol_layer->machine_name = 'openlayers_examples_layer_random_features';
+  $ol_layer->name = 'Openlayers examples: Random features';
+  $ol_layer->description = '';
+  $ol_layer->factory_service = 'openlayers.Layer:Vector';
+  $ol_layer->options = array(
+    'source' => 'openlayers_examples_source_random_features',
+    'visible' => 1,
+  );
+  $export['openlayers_examples_layer_random_features'] = $ol_layer;
+
   return $export;
 }

--- a/modules/openlayers_examples/includes/openlayers_examples.default_openlayers_maps.inc
+++ b/modules/openlayers_examples/includes/openlayers_examples.default_openlayers_maps.inc
@@ -1224,5 +1224,47 @@ function openlayers_examples_default_openlayers_maps() {
   );
   $export['openlayers_examples_map_ol3layerswitcher'] = $ol_map;
 
+  $ol_map = new stdClass();
+  $ol_map->disabled = FALSE; /* Edit this to true to make a default ol_map disabled initially */
+  $ol_map->api_version = 1;
+  $ol_map->machine_name = 'openlayers_examples_map_features_interactions';
+  $ol_map->name = 'Openlayers examples: Features & Interactions';
+  $ol_map->description = '';
+  $ol_map->factory_service = 'openlayers.Map:OLMap';
+  $ol_map->options = array(
+    'width' => 'auto',
+    'height' => '300px',
+    'provideBlock' => 0,
+    'provideBlockLayerSwitcher' => 0,
+    'contextualLinks' => 0,
+    'provideIframe' => 0,
+    'view' => array(
+      'center' => array(
+        'lat' => 0,
+        'lon' => 0,
+      ),
+      'rotation' => 0,
+      'zoom' => 2,
+      'minZoom' => 0,
+      'maxZoom' => 0,
+    ),
+    'renderer' => 'canvas',
+    'layers' => array(
+      0 => 'openlayers_examples_layer_openstreetmap_mapnik',
+      1 => 'openlayers_examples_layer_random_features',
+    ),
+    'controls' => array(
+      0 => 'openlayers_control_zoom',
+      1 => 'openlayers_control_fullscreen',
+    ),
+    'interactions' => array(
+      0 => 'openlayers_interaction_dragpan',
+      1 => 'openlayers_interaction_mousewheelzoom',
+      2 => 'openlayers_examples_interaction_select',
+      3 => 'openlayers_examples_interaction_drag_features',
+    ),
+  );
+  $export['openlayers_examples_map_features_interactions'] = $ol_map;
+
   return $export;
 }

--- a/modules/openlayers_examples/includes/openlayers_examples.default_openlayers_sources.inc
+++ b/modules/openlayers_examples/includes/openlayers_examples.default_openlayers_sources.inc
@@ -750,5 +750,25 @@ var source = new ol.source.Vector({
   );
   $export['openlayers_examples_source_tilewms'] = $ol_source;
 
+  $ol_source = new stdClass();
+  $ol_source->disabled = FALSE; /* Edit this to true to make a default ol_source disabled initially */
+  $ol_source->api_version = 1;
+  $ol_source->machine_name = 'openlayers_examples_source_random_features';
+  $ol_source->name = 'Openlayers examples: Random features';
+  $ol_source->description = '';
+  $ol_source->factory_service = 'openlayers.Source:Random';
+  $ol_source->options = array(
+    'Point' => array(
+      'count' => 50,
+    ),
+    'LineString' => array(
+      'count' => 20,
+    ),
+    'Polygon' => array(
+      'count' => 2,
+    ),
+  );
+  $export['openlayers_examples_source_random_features'] = $ol_source;
+
   return $export;
 }

--- a/modules/openlayers_examples/includes/openlayers_examples.default_openlayers_styles.inc
+++ b/modules/openlayers_examples/includes/openlayers_examples.default_openlayers_styles.inc
@@ -35,14 +35,27 @@ function openlayers_examples_default_openlayers_styles() {
   $ol_style->description = '';
   $ol_style->factory_service = 'openlayers.Style:Circle';
   $ol_style->options = array(
-    'fill' => array(
-      'color' => '0, 255, 0, 0.4',
+    'default' => array(
+      'image' => array(
+        'radius' => 5,
+        'fill' => array(
+          'color' => '0, 255, 0, 0.4',
+        ),
+        'stroke' => array(
+          'color' => '0, 255, 0, 1',
+          'width' => 1.25,
+          'lineDash' => '0,0',
+        ),
+      ),
+      'stroke' => array(
+        'color' => '0, 255, 0, 1',
+        'width' => 1.25,
+        'lineDash' => '0,0',
+      ),
+      'fill' => array(
+        'color' => '0, 255, 0, 0.4',
+      ),
     ),
-    'stroke' => array(
-      'color' => '0, 255, 0, 1',
-      'width' => 1.25,
-    ),
-    'radius' => 5,
   );
   $export['openlayers_examples_style_green'] = $ol_style;
 
@@ -54,14 +67,27 @@ function openlayers_examples_default_openlayers_styles() {
   $ol_style->description = '';
   $ol_style->factory_service = 'openlayers.Style:Circle';
   $ol_style->options = array(
-    'fill' => array(
-      'color' => '255, 0, 0, 0.4',
+    'default' => array(
+      'image' => array(
+        'radius' => 5,
+        'fill' => array(
+          'color' => '255, 0, 0, 0.4',
+        ),
+        'stroke' => array(
+          'color' => '255, 0, 0, 1',
+          'width' => 1.25,
+          'lineDash' => '0,0',
+        ),
+      ),
+      'stroke' => array(
+        'color' => '255, 0, 0, 1',
+        'width' => 1.25,
+        'lineDash' => '0,0',
+      ),
+      'fill' => array(
+        'color' => '255, 0, 0, 0.4',
+      ),
     ),
-    'stroke' => array(
-      'color' => '255, 0, 0, 1',
-      'width' => 1.25,
-    ),
-    'radius' => 5,
   );
   $export['openlayers_examples_style_red'] = $ol_style;
 
@@ -73,14 +99,27 @@ function openlayers_examples_default_openlayers_styles() {
   $ol_style->description = '';
   $ol_style->factory_service = 'openlayers.Style:Circle';
   $ol_style->options = array(
-    'fill' => array(
-      'color' => '0, 0, 255, 0.4',
+    'default' => array(
+      'image' => array(
+        'radius' => 5,
+        'fill' => array(
+          'color' => '0, 0, 255, 0.4',
+        ),
+        'stroke' => array(
+          'color' => '0, 0, 255, 1',
+          'width' => 1.25,
+          'lineDash' => '0,0',
+        ),
+      ),
+      'stroke' => array(
+        'color' => '0, 0, 255, 1',
+        'width' => 1.25,
+        'lineDash' => '0,0',
+      ),
+      'fill' => array(
+        'color' => '0, 0, 255, 0.4',
+      ),
     ),
-    'stroke' => array(
-      'color' => '0, 0, 255, 1',
-      'width' => 1.25,
-    ),
-    'radius' => 5,
   );
   $export['openlayers_examples_style_blue'] = $ol_style;
 
@@ -103,6 +142,186 @@ function openlayers_examples_default_openlayers_styles() {
   $ol_style->factory_service = 'openlayers.Style:Timezones';
   $ol_style->options = array();
   $export['openlayers_examples_style_timezones'] = $ol_style;
+
+  $ol_style = new stdClass();
+  $ol_style->disabled = FALSE; /* Edit this to true to make a default ol_style disabled initially */
+  $ol_style->api_version = 1;
+  $ol_style->machine_name = 'openlayers_examples_style_regularshape_square';
+  $ol_style->name = 'Openlayers examples: Square';
+  $ol_style->description = '';
+  $ol_style->factory_service = 'openlayers.Style:RegularShape';
+  $ol_style->options = array(
+    'default' => array(
+      'image' => array(
+        'points' => 4,
+        'radius' => 10,
+        'angle' => 45,
+        'rotation' => 0,
+        'fill' => array(
+          'color' => '255,255,255,0.4',
+        ),
+        'stroke' => array(
+          'color' => '51,153,204,1',
+          'width' => 1.25,
+          'lineDash' => '0,0',
+        ),
+      ),
+      'stroke' => array(
+        'color' => '51,153,204,1',
+        'width' => 1.25,
+        'lineDash' => '0,0',
+      ),
+      'fill' => array(
+        'color' => '51,153,204,1',
+      ),
+    ),
+  );
+  $export['openlayers_examples_style_regularshape_square'] = $ol_style;
+
+  $ol_style = new stdClass();
+  $ol_style->disabled = FALSE; /* Edit this to true to make a default ol_style disabled initially */
+  $ol_style->api_version = 1;
+  $ol_style->machine_name = 'openlayers_examples_style_regularshape_star';
+  $ol_style->name = 'Openlayers examples: Star';
+  $ol_style->description = '';
+  $ol_style->factory_service = 'openlayers.Style:RegularShape';
+  $ol_style->options = array(
+    'default' => array(
+      'image' => array(
+        'points' => 5,
+        'radius' => 10,
+        'radius2' => 4,
+        'angle' => 0,
+        'rotation' => 0,
+        'fill' => array(
+          'color' => '255,255,255,1',
+        ),
+        'stroke' => array(
+          'color' => '51,153,204,1',
+          'width' => 1.25,
+          'lineDash' => '0,0',
+        ),
+      ),
+      'stroke' => array(
+        'color' => '51,153,204,1',
+        'width' => 1.25,
+        'lineDash' => '0,0',
+      ),
+      'fill' => array(
+        'color' => '51,153,204,1',
+      ),
+    ),
+  );
+  $export['openlayers_examples_style_regularshape_star'] = $ol_style;
+
+  $ol_style = new stdClass();
+  $ol_style->disabled = FALSE; /* Edit this to true to make a default ol_style disabled initially */
+  $ol_style->api_version = 1;
+  $ol_style->machine_name = 'openlayers_examples_style_regularshape_triangle';
+  $ol_style->name = 'Openlayers examples: Triangle';
+  $ol_style->description = '';
+  $ol_style->factory_service = 'openlayers.Style:RegularShape';
+  $ol_style->options = array(
+    'default' => array(
+      'image' => array(
+        'points' => 3,
+        'radius' => 10,
+        'angle' => 0,
+        'rotation' => 60,
+        'fill' => array(
+          'color' => '255,255,255,0.4',
+        ),
+        'stroke' => array(
+          'color' => '51,153,204,1',
+          'width' => 1.25,
+          'lineDash' => '0,0',
+        ),
+      ),
+      'stroke' => array(
+        'color' => '51,153,204,1',
+        'width' => 1.25,
+        'lineDash' => '0,0',
+      ),
+      'fill' => array(
+        'color' => '51,153,204,1',
+      ),
+    ),
+  );
+  $export['openlayers_examples_style_regularshape_triangle'] = $ol_style;
+
+  $ol_style = new stdClass();
+  $ol_style->disabled = FALSE; /* Edit this to true to make a default ol_style disabled initially */
+  $ol_style->api_version = 1;
+  $ol_style->machine_name = 'openlayers_examples_style_regularshape_cross';
+  $ol_style->name = 'Openlayers examples: Cross';
+  $ol_style->description = '';
+  $ol_style->factory_service = 'openlayers.Style:RegularShape';
+  $ol_style->options = array(
+    'default' => array(
+      'image' => array(
+        'points' => 4,
+        'radius' => 10,
+        'radius1' => 0,
+        'radius2' => 0,
+        'angle' => 45,
+        'rotation' => 0,
+        'fill' => array(
+          'color' => '255,255,255,0.4',
+        ),
+        'stroke' => array(
+          'color' => '51,153,204,1',
+          'width' => 1.25,
+          'lineDash' => '0,0',
+        ),
+      ),
+      'stroke' => array(
+        'color' => '51,153,204,1',
+        'width' => 1.25,
+        'lineDash' => '0,0',
+      ),
+      'fill' => array(
+        'color' => '51,153,204,1',
+      ),
+    ),
+  );
+  $export['openlayers_examples_style_regularshape_cross'] = $ol_style;
+
+  $ol_style = new stdClass();
+  $ol_style->disabled = FALSE; /* Edit this to true to make a default ol_style disabled initially */
+  $ol_style->api_version = 1;
+  $ol_style->machine_name = 'openlayers_examples_style_regularshape_plus';
+  $ol_style->name = 'Openlayers examples: Plus';
+  $ol_style->description = '';
+  $ol_style->factory_service = 'openlayers.Style:RegularShape';
+  $ol_style->options = array(
+    'default' => array(
+      'image' => array(
+        'points' => 4,
+        'radius' => 10,
+        'radius1' => 0,
+        'radius2' => 0,
+        'angle' => 0,
+        'rotation' => 0,
+        'fill' => array(
+          'color' => '255,255,255,0.4',
+        ),
+        'stroke' => array(
+          'color' => '51,153,204,1',
+          'width' => 1.25,
+          'lineDash' => '0,0',
+        ),
+      ),
+      'stroke' => array(
+        'color' => '51,153,204,1',
+        'width' => 1.25,
+        'lineDash' => '0,0',
+      ),
+      'fill' => array(
+        'color' => '51,153,204,1',
+      ),
+    ),
+  );
+  $export['openlayers_examples_style_regularshape_plus'] = $ol_style;
 
   return $export;
 }

--- a/modules/openlayers_library/src/Plugin/Interaction/DragFeature/DragFeature.php
+++ b/modules/openlayers_library/src/Plugin/Interaction/DragFeature/DragFeature.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @file
+ * Interaction: DragFeature.
+ */
+
+namespace Drupal\openlayers_library\Plugin\Interaction\DragFeature;
+use Drupal\openlayers\Component\Annotation\OpenlayersPlugin;
+use Drupal\openlayers\Openlayers;
+use Drupal\openlayers\Types\Interaction;
+
+/**
+ * Class DragFeature.
+ *
+ * @OpenlayersPlugin(
+ *  id = "DragFeature",
+ *  description = "You can drag features around on the map."
+ * )
+ */
+class DragFeature extends Interaction {
+
+}

--- a/modules/openlayers_library/src/Plugin/Interaction/DragFeature/DragFeature.php
+++ b/modules/openlayers_library/src/Plugin/Interaction/DragFeature/DragFeature.php
@@ -18,5 +18,37 @@ use Drupal\openlayers\Types\Interaction;
  * )
  */
 class DragFeature extends Interaction {
+  /**
+   * {@inheritdoc}
+   */
+  public function optionsForm(&$form, &$form_state) {
+    $form['options']['style'] = array(
+      '#type' => 'select',
+      '#title' => t('Style when drag'),
+      '#empty_option' => t('- Select the Style -'),
+      '#default_value' => $this->getOption('style', array()),
+      '#description' => t('Select the style.'),
+      '#options' => Openlayers::loadAllAsOptions('Style'),
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function optionsToObjects() {
+    $import = parent::optionsToObjects();
+
+    if ($style = $this->getOption('style', FALSE)) {
+      $style = Openlayers::load('style', $style);
+
+      // This source is a dependency of the current one,
+      // we need a lighter weight.
+      $this->setWeight($style->getWeight() + 1);
+      $import = array_merge($style->getCollection()
+        ->getFlatList(), $import);
+    }
+
+    return $import;
+  }
 
 }

--- a/modules/openlayers_library/src/Plugin/Interaction/DragFeature/js/DragFeature.js
+++ b/modules/openlayers_library/src/Plugin/Interaction/DragFeature/js/DragFeature.js
@@ -1,0 +1,6 @@
+Drupal.openlayers.pluginManager.register({
+  fs: 'openlayers.Interaction:DragFeature',
+  init: function(data) {
+    return new ol.interaction.DragFeature(data.opt);
+  }
+});

--- a/modules/openlayers_library/src/Plugin/Interaction/DragFeature/js/DragFeature.js
+++ b/modules/openlayers_library/src/Plugin/Interaction/DragFeature/js/DragFeature.js
@@ -1,6 +1,6 @@
 Drupal.openlayers.pluginManager.register({
   fs: 'openlayers.Interaction:DragFeature',
   init: function(data) {
-    return new ol.interaction.DragFeature(data.opt);
+    return new ol.interaction.DragFeature(data);
   }
 });

--- a/modules/openlayers_library/src/Plugin/Interaction/DragFeature/js/DragFeatureInteraction.js
+++ b/modules/openlayers_library/src/Plugin/Interaction/DragFeature/js/DragFeatureInteraction.js
@@ -2,7 +2,9 @@
  * @constructor
  * @extends {ol.interaction.Pointer}
  */
-ol.interaction.DragFeature = function() {
+ol.interaction.DragFeature = function(data) {
+
+  var options = data.opt;
 
   ol.interaction.Pointer.call(this, {
     handleDownEvent: ol.interaction.DragFeature.prototype.handleDownEvent,
@@ -35,6 +37,13 @@ ol.interaction.DragFeature = function() {
    */
   this.previousCursor_ = undefined;
 
+  if (goog.isDef(data.objects.styles[options.style])) {
+    this.dragFeatureStyle_ = data.objects.styles[options.style];
+  } else {
+    this.dragFeatureStyle_ = ol.style.defaultStyleFunction;
+  }
+
+  this.style_ = null;
 };
 ol.inherits(ol.interaction.DragFeature, ol.interaction.Pointer);
 
@@ -54,6 +63,7 @@ ol.interaction.DragFeature.prototype.handleDownEvent = function(evt) {
   if (feature) {
     this.coordinate_ = evt.coordinate;
     this.feature_ = feature;
+    this.style_ = feature.getStyleFunction();
   }
 
   return !!feature;
@@ -77,6 +87,8 @@ ol.interaction.DragFeature.prototype.handleDragEvent = function(evt) {
   var geometry = /** @type {ol.geom.SimpleGeometry} */
     (this.feature_.getGeometry());
   geometry.translate(deltaX, deltaY);
+
+  this.feature_.setStyle(this.dragFeatureStyle_(feature));
 
   this.coordinate_[0] = evt.coordinate[0];
   this.coordinate_[1] = evt.coordinate[1];
@@ -113,6 +125,12 @@ ol.interaction.DragFeature.prototype.handleMoveEvent = function(evt) {
  */
 ol.interaction.DragFeature.prototype.handleUpEvent = function(evt) {
   this.coordinate_ = null;
+  if (typeof this.style_ === 'undefined') {
+    this.feature_.setStyle(ol.style.defaultStyleFunction);
+  } else {
+    this.feature_.setStyle(this.style_(this.feature_));
+  }
+  this.style_ = null;
   this.feature_ = null;
   return false;
 };

--- a/modules/openlayers_library/src/Plugin/Interaction/DragFeature/js/DragFeatureInteraction.js
+++ b/modules/openlayers_library/src/Plugin/Interaction/DragFeature/js/DragFeatureInteraction.js
@@ -1,0 +1,118 @@
+/**
+ * @constructor
+ * @extends {ol.interaction.Pointer}
+ */
+ol.interaction.DragFeature = function() {
+
+  ol.interaction.Pointer.call(this, {
+    handleDownEvent: ol.interaction.DragFeature.prototype.handleDownEvent,
+    handleDragEvent: ol.interaction.DragFeature.prototype.handleDragEvent,
+    handleMoveEvent: ol.interaction.DragFeature.prototype.handleMoveEvent,
+    handleUpEvent: ol.interaction.DragFeature.prototype.handleUpEvent
+  });
+
+  /**
+   * @type {ol.Pixel}
+   * @private
+   */
+  this.coordinate_ = null;
+
+  /**
+   * @type {string|undefined}
+   * @private
+   */
+  this.cursor_ = 'pointer';
+
+  /**
+   * @type {ol.Feature}
+   * @private
+   */
+  this.feature_ = null;
+
+  /**
+   * @type {string|undefined}
+   * @private
+   */
+  this.previousCursor_ = undefined;
+
+};
+ol.inherits(ol.interaction.DragFeature, ol.interaction.Pointer);
+
+
+/**
+ * @param {ol.MapBrowserEvent} evt Map browser event.
+ * @return {boolean} `true` to start the drag sequence.
+ */
+ol.interaction.DragFeature.prototype.handleDownEvent = function(evt) {
+  var map = evt.map;
+
+  var feature = map.forEachFeatureAtPixel(evt.pixel,
+    function(feature, layer) {
+      return feature;
+    });
+
+  if (feature) {
+    this.coordinate_ = evt.coordinate;
+    this.feature_ = feature;
+  }
+
+  return !!feature;
+};
+
+
+/**
+ * @param {ol.MapBrowserEvent} evt Map browser event.
+ */
+ol.interaction.DragFeature.prototype.handleDragEvent = function(evt) {
+  var map = evt.map;
+
+  var feature = map.forEachFeatureAtPixel(evt.pixel,
+    function(feature, layer) {
+      return feature;
+    });
+
+  var deltaX = evt.coordinate[0] - this.coordinate_[0];
+  var deltaY = evt.coordinate[1] - this.coordinate_[1];
+
+  var geometry = /** @type {ol.geom.SimpleGeometry} */
+    (this.feature_.getGeometry());
+  geometry.translate(deltaX, deltaY);
+
+  this.coordinate_[0] = evt.coordinate[0];
+  this.coordinate_[1] = evt.coordinate[1];
+};
+
+
+/**
+ * @param {ol.MapBrowserEvent} evt Event.
+ */
+ol.interaction.DragFeature.prototype.handleMoveEvent = function(evt) {
+  if (this.cursor_) {
+    var map = evt.map;
+    var feature = map.forEachFeatureAtPixel(evt.pixel,
+      function(feature, layer) {
+        return feature;
+      });
+    var element = evt.map.getTargetElement();
+    if (feature) {
+      if (element.style.cursor != this.cursor_) {
+        this.previousCursor_ = element.style.cursor;
+        element.style.cursor = this.cursor_;
+      }
+    } else if (this.previousCursor_ !== undefined) {
+      element.style.cursor = this.previousCursor_;
+      this.previousCursor_ = undefined;
+    }
+  }
+};
+
+
+/**
+ * @param {ol.MapBrowserEvent} evt Map browser event.
+ * @return {boolean} `false` to stop the drag sequence.
+ */
+ol.interaction.DragFeature.prototype.handleUpEvent = function(evt) {
+  this.coordinate_ = null;
+  this.feature_ = null;
+  return false;
+};

--- a/modules/openlayers_library/src/Plugin/Source/Random/Random.php
+++ b/modules/openlayers_library/src/Plugin/Source/Random/Random.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @file
+ * Source: Random.
+ */
+
+namespace Drupal\openlayers_library\Plugin\Source\Random;
+use Drupal\openlayers\Component\Annotation\OpenlayersPlugin;
+use Drupal\openlayers\Openlayers;
+use Drupal\openlayers\Types\Source;
+
+/**
+ * Class Random.
+ *
+ * @OpenlayersPlugin(
+ *  id = "Random"
+ * )
+ */
+class Random extends Source {
+  /**
+   * {@inheritdoc}
+   */
+  public function optionsForm(&$form, &$form_state) {
+    $form['options']['count'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Number of features'),
+      '#default_value' => $this->getOption('count', 250),
+      '#required' => TRUE,
+    );
+    $form['options']['setRandomStyle'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Set random style on features ?'),
+      '#default_value' => $this->getOption('setRandomStyle', 0),
+    );
+    $form['options']['style'] = array(
+      '#type' => 'select',
+      '#title' => t('Styles'),
+      '#empty_option' => t('- Select the Styles -'),
+      '#default_value' => $this->getOption('style', array()),
+      '#description' => t('Select the styles.'),
+      '#options' => Openlayers::loadAllAsOptions('Style'),
+      '#required' => TRUE,
+      '#multiple' => TRUE,
+      '#states' => array(
+        'visible' => array(
+          'input[name="options[setRandomStyle]"' => array('checked' => TRUE),
+        ),
+      ),
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function optionsToObjects() {
+    $import = parent::optionsToObjects();
+
+    if ($styles = $this->getOption('style', array())) {
+      foreach($styles as $style) {
+        $style = Openlayers::load('style', $style);
+
+        // This source is a dependency of the current one,
+        // we need a lighter weight.
+        $this->setWeight($style->getWeight() + 1);
+        $import = array_merge($style->getCollection()->getFlatList(), $import);
+      }
+    }
+
+    return $import;
+  }
+}

--- a/modules/openlayers_library/src/Plugin/Source/Random/Random.php
+++ b/modules/openlayers_library/src/Plugin/Source/Random/Random.php
@@ -21,32 +21,65 @@ class Random extends Source {
    * {@inheritdoc}
    */
   public function optionsForm(&$form, &$form_state) {
-    $form['options']['count'] = array(
-      '#type' => 'textfield',
-      '#title' => t('Number of features'),
-      '#default_value' => $this->getOption('count', 250),
-      '#required' => TRUE,
-    );
-    $form['options']['setRandomStyle'] = array(
-      '#type' => 'checkbox',
-      '#title' => t('Set random style on features ?'),
-      '#default_value' => $this->getOption('setRandomStyle', 0),
-    );
-    $form['options']['style'] = array(
-      '#type' => 'select',
-      '#title' => t('Styles'),
-      '#empty_option' => t('- Select the Styles -'),
-      '#default_value' => $this->getOption('style', array()),
-      '#description' => t('Select the styles.'),
-      '#options' => Openlayers::loadAllAsOptions('Style'),
-      '#required' => TRUE,
-      '#multiple' => TRUE,
-      '#states' => array(
-        'visible' => array(
-          'input[name="options[setRandomStyle]"' => array('checked' => TRUE),
+    foreach (Openlayers::getGeometryTypes() as $geometry_type => $geometry) {
+      if (!in_array($geometry_type, array('Point', 'LineString', 'Polygon'))) {
+        continue;
+      }
+      $enabled = (bool) $this->getOption(array($geometry_type, 'count'), FALSE);
+      $form['options'][$geometry_type] = array(
+        '#type' => 'fieldset',
+        '#title' => t('Geometry @geometry', array('@geometry' => $geometry)),
+        '#collapsible' => TRUE,
+        '#collapsed' => !$enabled,
+      );
+      $form['options'][$geometry_type]['count'] = array(
+        '#type' => 'textfield',
+        '#title' => t('Number of features'),
+        '#default_value' => $this->getOption(array($geometry_type, 'count'), 0),
+        '#required' => TRUE,
+      );
+      $form['options'][$geometry_type]['setRandomStyle'] = array(
+        '#type' => 'checkbox',
+        '#title' => t('Set random style on features ?'),
+        '#default_value' => $this->getOption(array($geometry_type, 'setRandomStyle'), 0),
+      );
+      $form['options'][$geometry_type]['styles'] = array(
+        '#type' => 'select',
+        '#title' => t('Styles'),
+        '#empty_option' => t('- Select the Styles -'),
+        '#default_value' => $this->getOption(array($geometry_type, 'styles'), array()),
+        '#description' => t('Select the styles.'),
+        '#options' => Openlayers::loadAllAsOptions('Style'),
+        '#multiple' => TRUE,
+        '#states' => array(
+          'visible' => array(
+            'input[name="options[' . $geometry_type . '][setRandomStyle]"' => array('checked' => TRUE),
+          ),
         ),
-      ),
-    );
+      );
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function optionsFormSubmit($form, &$form_state) {
+    parent::optionsFormSubmit($form, $form_state);
+
+    $options = $this->getOptions();
+    foreach ($options as $geometry_type => $data) {
+      if ($data['setRandomStyle'] != 1) {
+        unset($options[$geometry_type]['styles']);
+        unset($options[$geometry_type]['setRandomStyle']);
+      }
+      if ($data['count'] == 0) {
+        unset($options[$geometry_type]);
+      }
+    }
+
+    $this->setOptions($options);
+    $form_state['values']['options'] = $options;
+    parent::optionsFormSubmit($form, $form_state);
   }
 
   /**
@@ -55,17 +88,20 @@ class Random extends Source {
   public function optionsToObjects() {
     $import = parent::optionsToObjects();
 
-    if ($styles = $this->getOption('style', array())) {
-      foreach($styles as $style) {
-        $style = Openlayers::load('style', $style);
+    foreach ($this->getOptions() as $geometry_type => $data) {
+      if ($styles = $this->getOption(array($geometry_type, 'styles'), array())) {
+        foreach ($styles as $style) {
+          $style = Openlayers::load('style', $style);
 
-        // This source is a dependency of the current one,
-        // we need a lighter weight.
-        $this->setWeight($style->getWeight() + 1);
-        $import = array_merge($style->getCollection()->getFlatList(), $import);
+          // This source is a dependency of the current one,
+          // we need a lighter weight.
+          $this->setWeight($style->getWeight() + 1);
+          $import = array_merge($style->getCollection()->getFlatList(), $import);
+        }
       }
     }
 
     return $import;
   }
+
 }

--- a/modules/openlayers_library/src/Plugin/Source/Random/js/Random.js
+++ b/modules/openlayers_library/src/Plugin/Source/Random/js/Random.js
@@ -1,0 +1,35 @@
+Drupal.openlayers.pluginManager.register({
+  fs: 'openlayers.Source:Random',
+  init: function(data) {
+
+    var randomProperty = function (obj) {
+      var keys = Object.keys(obj);
+      return obj[keys[ keys.length * Math.random() << 0]];
+    };
+
+    var count = data.opt.count;
+    var features = new Array(count);
+    var e = 9000000;
+    for (var i = 0; i < count; ++i) {
+      var coordinates = [2 * e * Math.random() - e, 2 * e * Math.random() - e];
+      features[i] = new ol.Feature(new ol.geom.Point(coordinates));
+      if (data.opt.setRandomStyle === 1) {
+        var style = randomProperty(data.opt.style);
+        if (goog.isDef(data.objects.styles[style])) {
+          if (typeof data.objects.styles[style] === 'function') {
+            style = data.objects.styles[style](features[i]);
+          } else {
+            style = data.objects.styles[style];
+          }
+          features[i].setStyle(style);
+        }
+      }
+    }
+
+    var options = {
+      features: features
+    };
+
+    return new ol.source.Vector(options);
+  }
+});

--- a/modules/openlayers_library/src/Plugin/Source/Random/js/Random.js
+++ b/modules/openlayers_library/src/Plugin/Source/Random/js/Random.js
@@ -1,35 +1,62 @@
 Drupal.openlayers.pluginManager.register({
   fs: 'openlayers.Source:Random',
   init: function(data) {
+    var features = [];
 
     var randomProperty = function (obj) {
       var keys = Object.keys(obj);
       return obj[keys[ keys.length * Math.random() << 0]];
     };
 
-    var count = data.opt.count;
-    var features = new Array(count);
-    var e = 9000000;
-    for (var i = 0; i < count; ++i) {
-      var coordinates = [2 * e * Math.random() - e, 2 * e * Math.random() - e];
-      features[i] = new ol.Feature(new ol.geom.Point(coordinates));
-      if (data.opt.setRandomStyle === 1) {
-        var style = randomProperty(data.opt.style);
-        if (goog.isDef(data.objects.styles[style])) {
-          if (typeof data.objects.styles[style] === 'function') {
-            style = data.objects.styles[style](features[i]);
-          } else {
-            style = data.objects.styles[style];
-          }
-          features[i].setStyle(style);
+    var getRandomCoordinates = function(count) {
+      var e = 9000000;
+      var coordinates = [];
+      for (var c = 0; c < count; c++) {
+        coordinates.push([2 * e * Math.random() - e, 2 * e * Math.random() - e]);
+      }
+      return coordinates;
+    };
+
+    for (var geometry_type in data.opt) {
+      var count = data.opt[geometry_type].count;
+
+      for (var i = 0; i < count; ++i) {
+        switch (geometry_type) {
+          case 'Point':
+            var coordinates = getRandomCoordinates(1);
+            geometry = new ol.geom.Point(coordinates[0]);
+            break;
+          case 'LineString':
+            geometry = new ol.geom.LineString(getRandomCoordinates(2));
+            break;
+          case 'Polygon':
+            coordinates = getRandomCoordinates(4);
+            coordinates.push(coordinates[0]);
+            geometry = new ol.geom.Polygon([coordinates]);
+            break;
         }
+        var feature = new ol.Feature(geometry);
+
+        if (data.opt[geometry_type].setRandomStyle === 1) {
+          if (goog.isDef(data.opt[geometry_type].styles)) {
+            var style = randomProperty(data.opt[geometry_type].styles);
+            if (goog.isDef(data.objects.styles[style])) {
+              if (typeof data.objects.styles[style] === 'function') {
+                style = data.objects.styles[style](feature);
+              } else {
+                style = data.objects.styles[style];
+              }
+              feature.setStyle(style);
+            }
+          }
+        }
+
+        features.push(feature);
       }
     }
 
-    var options = {
+    return new ol.source.Vector({
       features: features
-    };
-
-    return new ol.source.Vector(options);
+    });
   }
 });

--- a/modules/openlayers_library/src/Plugin/Style/Random/Random.php
+++ b/modules/openlayers_library/src/Plugin/Style/Random/Random.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @file
+ * Style: Random.
+ */
+
+namespace Drupal\openlayers_library\Plugin\Style\Random;
+use Drupal\openlayers\Component\Annotation\OpenlayersPlugin;
+use Drupal\openlayers\Openlayers;
+use Drupal\openlayers\Types\Style;
+
+/**
+ * Class Random.
+ *
+ * @OpenlayersPlugin(
+ *  id = "Random"
+ * )
+ */
+class Random extends Style {
+  /**
+   * {@inheritdoc}
+   */
+  public function optionsForm(&$form, &$form_state) {
+    $form['options']['style'] = array(
+      '#type' => 'select',
+      '#title' => t('Styles'),
+      '#empty_option' => t('- Select the Styles -'),
+      '#default_value' => $this->getOption('style', array()),
+      '#description' => t('Select the source.'),
+      '#options' => Openlayers::loadAllAsOptions('Style'),
+      '#required' => TRUE,
+      '#multiple' => TRUE,
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function optionsToObjects() {
+    $import = parent::optionsToObjects();
+
+    if ($styles = $this->getOption('style', array())) {
+      foreach($styles as $style) {
+        $style = Openlayers::load('style', $style);
+
+        // This source is a dependency of the current one,
+        // we need a lighter weight.
+        $this->setWeight($style->getWeight() + 1);
+        $import = array_merge($style->getCollection()->getFlatList(), $import);
+      }
+    }
+
+    return $import;
+  }
+}

--- a/modules/openlayers_library/src/Plugin/Style/Random/js/Random.js
+++ b/modules/openlayers_library/src/Plugin/Style/Random/js/Random.js
@@ -1,0 +1,15 @@
+Drupal.openlayers.pluginManager.register({
+  fs: 'openlayers.Style:Random',
+  init: function(data) {
+    var randomProperty = function (obj) {
+      var keys = Object.keys(obj);
+      return obj[keys[ keys.length * Math.random() << 0]];
+    };
+
+    var style = randomProperty(data.opt.style);
+
+    if (goog.isDef(data.objects.styles[style])) {
+      return data.objects.styles[style];
+    }
+  }
+});

--- a/src/Component/Annotation/OpenlayersPlugin.php
+++ b/src/Component/Annotation/OpenlayersPlugin.php
@@ -10,7 +10,7 @@ namespace Drupal\openlayers\Component\Annotation;
 use Drupal\Component\Annotation\Plugin;
 
 /**
- * Defines a Leaflet Plugin annotation object.
+ * Defines an Openlayers Plugin annotation object.
  *
  * @ingroup plugin_api
  *

--- a/src/Openlayers.php
+++ b/src/Openlayers.php
@@ -329,4 +329,25 @@ class Openlayers {
       'top-right' => t('top-right'),
     );
   }
+
+  /**
+   * The list of geometries available.
+   *
+   * @return array
+   *   The list of geometries.
+   */
+  public static function getGeometryTypes() {
+    return array(
+      'Point' => t('Point'),
+      'MultiPoint' => t('MultiPoint'),
+      'LineString' => t('LineString'),
+      'LinearRing' => t('LinearRing'),
+      'MultiLineString' => t('MultiLineString'),
+      'Polygon' => t('Polygon'),
+      'MultiPolygon' => t('Polygon'),
+      'GeometryCollection' => t('GeometryCollection'),
+      'Circle' => t('Circle'),
+    );
+  }
+
 }

--- a/src/Openlayers.php
+++ b/src/Openlayers.php
@@ -344,7 +344,7 @@ class Openlayers {
       'LinearRing' => t('LinearRing'),
       'MultiLineString' => t('MultiLineString'),
       'Polygon' => t('Polygon'),
-      'MultiPolygon' => t('Polygon'),
+      'MultiPolygon' => t('MultiPolygon'),
       'GeometryCollection' => t('GeometryCollection'),
       'Circle' => t('Circle'),
     );

--- a/src/Openlayers.php
+++ b/src/Openlayers.php
@@ -298,9 +298,9 @@ class Openlayers {
    * @return array
    *   The cleaned array.
    */
-  public static function removeEmptyElements($array) {
+  public static function removeEmptyElements(array $array) {
     foreach ($array as $key => $value) {
-      if (empty($value) && $value != 0) {
+      if ($value === '' && $value !== 0) {
         unset($array[$key]);
       }
       elseif (is_array($value)) {

--- a/src/Plugin/Interaction/Select/Select.php
+++ b/src/Plugin/Interaction/Select/Select.php
@@ -32,7 +32,7 @@ class Select extends Interaction {
       '#type' => 'select',
       '#title' => t('Condition'),
       '#empty_option' => t('- Select a condition -'),
-      '#default_value' => $this->getOption('condition', 'singleClick'),
+      '#default_value' => $this->getOption('condition', ''),
       '#description' => t('Select the condition.'),
       '#options' => array(
         'singleClick' => t('Single click'),

--- a/src/Plugin/Interaction/Select/Select.php
+++ b/src/Plugin/Interaction/Select/Select.php
@@ -22,6 +22,12 @@ class Select extends Interaction {
    * {@inheritdoc}
    */
   public function optionsForm(&$form, &$form_state) {
+    $form['options']['multi'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Multi select ?'),
+      '#default_value' => $this->getOption('multi', TRUE),
+      '#description' => t('A boolean that determines if the default behaviour should select only single features or all (overlapping) features at the clicked map position. Default is false i.e single select.'),
+    );
     $form['options']['condition'] = array(
       '#type' => 'select',
       '#title' => t('Condition'),
@@ -33,7 +39,32 @@ class Select extends Interaction {
         'shiftKeyOnly' => t('Shift key only'),
         'pointerMove' => t('Pointer move'),
       ),
-      '#required' => TRUE,
+    );
+    $form['options']['addCondition'] = array(
+      '#type' => 'select',
+      '#title' => t('Add condition'),
+      '#empty_option' => t('- Select an add condition -'),
+      '#default_value' => $this->getOption('addCondition', 'never'),
+      '#description' => t('Select the add condition.'),
+      '#options' => array(
+        'never' => t('Never'),
+        'singleClick' => t('Single click'),
+        'shiftKeyOnly' => t('Shift key only'),
+        'pointerMove' => t('Pointer move'),
+      ),
+    );
+    $form['options']['toggleCondition'] = array(
+      '#type' => 'select',
+      '#title' => t('Toggle condition'),
+      '#empty_option' => t('- Select a toggle condition -'),
+      '#default_value' => $this->getOption('toggleCondition', 'shiftKeyOnly'),
+      '#description' => t('Select the toggle condition.'),
+      '#options' => array(
+        'never' => t('Never'),
+        'singleClick' => t('Single click'),
+        'shiftKeyOnly' => t('Shift key only'),
+        'pointerMove' => t('Pointer move'),
+      ),
     );
     $form['options']['style'] = array(
       '#type' => 'select',

--- a/src/Plugin/Interaction/Select/Select.php
+++ b/src/Plugin/Interaction/Select/Select.php
@@ -22,6 +22,19 @@ class Select extends Interaction {
    * {@inheritdoc}
    */
   public function optionsForm(&$form, &$form_state) {
+    $form['options']['condition'] = array(
+      '#type' => 'select',
+      '#title' => t('Condition'),
+      '#empty_option' => t('- Select a condition -'),
+      '#default_value' => $this->getOption('condition', 'singleClick'),
+      '#description' => t('Select the condition.'),
+      '#options' => array(
+        'singleClick' => t('Single click'),
+        'shiftKeyOnly' => t('Shift key only'),
+        'pointerMove' => t('Pointer move'),
+      ),
+      '#required' => TRUE,
+    );
     $form['options']['style'] = array(
       '#type' => 'select',
       '#title' => t('Style'),

--- a/src/Plugin/Interaction/Select/Select.php
+++ b/src/Plugin/Interaction/Select/Select.php
@@ -6,15 +6,49 @@
 
 namespace Drupal\openlayers\Plugin\Interaction\Select;
 use Drupal\openlayers\Component\Annotation\OpenlayersPlugin;
+use Drupal\openlayers\Openlayers;
 use Drupal\openlayers\Types\Interaction;
 
 /**
  * Class Select.
  *
  * @OpenlayersPlugin(
- *  id = "Select"
+ *  id = "Select",
+ *  description = "Handles selection of vector data."
  * )
  */
 class Select extends Interaction {
+  /**
+   * {@inheritdoc}
+   */
+  public function optionsForm(&$form, &$form_state) {
+    $form['options']['style'] = array(
+      '#type' => 'select',
+      '#title' => t('Style'),
+      '#empty_option' => t('- Select a Style -'),
+      '#default_value' => $this->getOption('style', ''),
+      '#description' => t('Select the source.'),
+      '#options' => Openlayers::loadAllAsOptions('Style'),
+      '#required' => TRUE,
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function optionsToObjects() {
+    $import = parent::optionsToObjects();
+
+    if ($style = $this->getOption('style')) {
+      $style = Openlayers::load('style', $style);
+
+      // This style is a dependency of the current one,
+      // we need a lighter weight.
+      $this->setWeight($style->getWeight() + 1);
+      $import = array_merge($style->getCollection()->getFlatList(), $import);
+    }
+
+    return $import;
+  }
 
 }

--- a/src/Plugin/Interaction/Select/js/select.js
+++ b/src/Plugin/Interaction/Select/js/select.js
@@ -1,10 +1,26 @@
 Drupal.openlayers.pluginManager.register({
   fs: 'openlayers.Interaction:Select',
   init: function(data) {
+    var options = jQuery.extend(true, {}, data.opt);
+
     if (goog.isDef(data.objects.styles[data.opt.style])) {
-      var options = jQuery.extend(true, {}, data.opt);
       options.style = data.objects.styles[data.opt.style];
-      return new ol.interaction.Select(options);
     }
+
+    if (goog.isDef(data.opt.condition)) {
+      switch (data.opt.condition) {
+        case 'singleClick':
+          condition = ol.events.condition.singleClick;
+          break;
+        case 'shiftKeyOnly':
+          condition = ol.events.condition.shiftKeyOnly;
+          break;
+        case 'pointerMove':
+          condition = ol.events.condition.pointerMove;
+          break;
+      }
+      options.condition = condition;
+    }
+    return new ol.interaction.Select(options);
   }
 });

--- a/src/Plugin/Interaction/Select/js/select.js
+++ b/src/Plugin/Interaction/Select/js/select.js
@@ -3,24 +3,45 @@ Drupal.openlayers.pluginManager.register({
   init: function(data) {
     var options = jQuery.extend(true, {}, data.opt);
 
+    function getOlEventsCondition(type) {
+      var condition = null;
+      switch (type) {
+        case 'never':
+          condition = ol.events.condition[type];
+          break;
+        case 'singleClick':
+          condition = ol.events.condition[type];
+          break;
+        case 'shiftKeyOnly':
+          condition = ol.events.condition[type];
+          break;
+        case 'pointerMove':
+          condition = ol.events.condition[type];
+          break;
+      }
+      return condition;
+    }
+
     if (goog.isDef(data.objects.styles[data.opt.style])) {
       options.style = data.objects.styles[data.opt.style];
     }
 
-    if (goog.isDef(data.opt.condition)) {
-      switch (data.opt.condition) {
-        case 'singleClick':
-          condition = ol.events.condition.singleClick;
-          break;
-        case 'shiftKeyOnly':
-          condition = ol.events.condition.shiftKeyOnly;
-          break;
-        case 'pointerMove':
-          condition = ol.events.condition.pointerMove;
-          break;
-      }
-      options.condition = condition;
+    if (goog.isDef(data.opt.multi) && data.opt.multi === 1) {
+      options.multi = true;
     }
+
+    if (goog.isDef(data.opt.condition)) {
+      options.condition = getOlEventsCondition(data.opt.condition);
+    }
+
+    if (goog.isDef(data.opt.addCondition)) {
+      options.addCondition = getOlEventsCondition(data.opt.addCondition);
+    }
+
+    if (goog.isDef(data.opt.toggleCondition)) {
+      options.toggleCondition = getOlEventsCondition(data.opt.toggleCondition);
+    }
+
     return new ol.interaction.Select(options);
   }
 });

--- a/src/Plugin/Interaction/Select/js/select.js
+++ b/src/Plugin/Interaction/Select/js/select.js
@@ -1,6 +1,10 @@
 Drupal.openlayers.pluginManager.register({
   fs: 'openlayers.Interaction:Select',
   init: function(data) {
-    return new ol.interaction.Select(data.opt);
+    if (goog.isDef(data.objects.styles[data.opt.style])) {
+      var options = jQuery.extend(true, {}, data.opt);
+      options.style = data.objects.styles[data.opt.style];
+      return new ol.interaction.Select(options);
+    }
   }
 });

--- a/src/Plugin/Interaction/Snap/js/snap.js
+++ b/src/Plugin/Interaction/Snap/js/snap.js
@@ -1,10 +1,10 @@
 Drupal.openlayers.pluginManager.register({
   fs: 'openlayers.Interaction:Snap',
   init: function(data) {
-    if (goog.isDef(data.opt) && goog.isDef(data.opt.source) && goog.isDef(data.objects.sources[data.opt.source])) {
-      data.opt.source = data.objects.sources[data.opt.source];
+    if (goog.isDef(data.objects.sources[data.opt.source])) {
+      var options = jQuery.extend(true, {}, data.opt);
+      options.source = data.objects.sources[data.opt.source];
+      return new ol.interaction.Snap(options);
     }
-
-    return new ol.interaction.Snap(data.opt);
   }
 });

--- a/src/Plugin/Source/Cluster/Cluster.php
+++ b/src/Plugin/Source/Cluster/Cluster.php
@@ -25,7 +25,7 @@ class Cluster extends Source {
       '#type' => 'select',
       '#title' => t('Source'),
       '#empty_option' => t('- Select a Source -'),
-      '#default_value' => isset($form_state['item']->options['source']) ? $form_state['item']->options['source'] : '',
+      '#default_value' => $this->getOption('source', ''),
       '#description' => t('Select the source.'),
       '#options' => Openlayers::loadAllAsOptions('Source'),
       '#required' => TRUE,

--- a/src/Plugin/Style/Circle/Circle.php
+++ b/src/Plugin/Style/Circle/Circle.php
@@ -69,6 +69,12 @@ class Circle extends Style {
       '#default_value' => $this->getOption(array('default', 'image', 'stroke', 'width'), '1.25'),
       '#required' => TRUE,
     );
+    $form['options']['default']['image']['stroke']['lineDash'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Line dash',
+      '#default_value' => $this->getOption(array('default', 'image', 'stroke', 'lineDash'), '0,0'),
+      '#required' => TRUE,
+    );
     $form['options']['default']['stroke']['lineDash'] = array(
       '#type' => 'textfield',
       '#title' => 'Line dash',

--- a/src/Plugin/Style/Circle/Circle.php
+++ b/src/Plugin/Style/Circle/Circle.php
@@ -6,6 +6,7 @@
 
 namespace Drupal\openlayers\Plugin\Style\Circle;
 use Drupal\openlayers\Component\Annotation\OpenlayersPlugin;
+use Drupal\openlayers\Openlayers;
 use Drupal\openlayers\Types\Style;
 
 /**
@@ -20,34 +21,156 @@ class Circle extends Style {
    * @inheritDoc
    */
   public function optionsForm(&$form, &$form_state) {
-    $form['options']['radius'] = array(
+    $form['options']['default'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('Default'),
+      '#collapsible' => TRUE,
+    );
+    $form['options']['default']['image']['radius'] = array(
       '#type' => 'textfield',
       '#title' => 'Radius',
-      '#default_value' => $this->getOption('radius', '5'),
+      '#default_value' => $this->getOption(array('default', 'radius'), '5'),
+      '#required' => TRUE,
     );
-    $form['options']['fill']['color'] = array(
+    $form['options']['default']['image']['fill']['color'] = array(
       '#type' => 'textfield',
       '#title' => 'Fill color',
       '#field_prefix' => 'rgba(',
       '#field_suffix' => ')',
-      '#default_value' => $this->getOption(array('fill', 'color'), '255,255,255,0.4'),
+      '#default_value' => $this->getOption(array('default', 'image', 'fill', 'color'), '255,255,255,0.4'),
+      '#required' => TRUE,
     );
-    $form['options']['stroke'] = array(
-      '#type' => 'fieldset',
-      '#title' => 'Stroke',
-    );
-    $form['options']['stroke']['color'] = array(
+    $form['options']['default']['image']['stroke']['color'] = array(
       '#type' => 'textfield',
       '#title' => 'Color',
       '#field_prefix' => 'rgba(',
       '#field_suffix' => ')',
-      '#default_value' => $this->getOption(array('stroke', 'color'), '51,153,204,1'),
+      '#default_value' => $this->getOption(array('default', 'image', 'stroke', 'color'), '51,153,204,1'),
+      '#required' => TRUE,
     );
-    $form['options']['stroke']['width'] = array(
+    $form['options']['default']['stroke'] = array(
+      '#type' => 'fieldset',
+      '#title' => 'Stroke',
+    );
+    $form['options']['default']['stroke']['color'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Color',
+      '#field_prefix' => 'rgba(',
+      '#field_suffix' => ')',
+      '#default_value' => $this->getOption(array('default', 'stroke', 'color'), '51,153,204,1'),
+      '#required' => TRUE,
+    );
+    $form['options']['default']['stroke']['width'] = array(
       '#type' => 'textfield',
       '#title' => 'Width',
-      '#default_value' => $this->getOption(array('stroke', 'width'), 1.25),
+      '#default_value' => $this->getOption(array('default', 'stroke', 'width'), 1.25),
+      '#required' => TRUE,
     );
+    $form['options']['default']['stroke']['lineDash'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Width',
+      '#description' => 'Two integers separated by a comma. The comma is mandatory. Default to disable is <em>0,0</em>.',
+      '#default_value' => $this->getOption(array('default', 'stroke', 'lineDash'), '0,0'),
+      '#required' => TRUE,
+    );
+    $form['options']['default']['fill'] = array(
+      '#type' => 'fieldset',
+      '#title' => 'Fill',
+    );
+    $form['options']['default']['fill']['color'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Color',
+      '#field_prefix' => 'rgba(',
+      '#field_suffix' => ')',
+      '#default_value' => $this->getOption(array('default', 'fill', 'color'), '51,153,204,1'),
+      '#required' => TRUE,
+    );
+
+    foreach (Openlayers::getGeometryTypes() as $geometry_type => $geometry) {
+      $enabled = (bool) $this->getOption(array($geometry_type, 'enabled'), FALSE);
+
+      $form['options'][$geometry_type] = array(
+        '#type' => 'fieldset',
+        '#title' => t('Geometry @geometry', array('@geometry' => $geometry)),
+        '#collapsible' => TRUE,
+        '#collapsed' => !$enabled,
+      );
+      $form['options'][$geometry_type]['enabled'] = array(
+        '#type' => 'checkbox',
+        '#title' => t('Enable this geometry type ?'),
+        '#default_value' => $enabled,
+      );
+      $form['options'][$geometry_type]['image']['radius'] = array(
+        '#type' => 'textfield',
+        '#title' => 'Radius',
+        '#default_value' => $this->getOption(array($geometry_type, 'image', 'radius'), '5'),
+      );
+      $form['options'][$geometry_type]['image']['fill']['color'] = array(
+        '#type' => 'textfield',
+        '#title' => 'Fill color',
+        '#field_prefix' => 'rgba(',
+        '#field_suffix' => ')',
+        '#default_value' => $this->getOption(array($geometry_type, 'image', 'fill', 'color'), '255,255,255,0.4'),
+      );
+      $form['options'][$geometry_type]['image']['stroke']['color'] = array(
+        '#type' => 'textfield',
+        '#title' => 'Color',
+        '#field_prefix' => 'rgba(',
+        '#field_suffix' => ')',
+        '#default_value' => $this->getOption(array($geometry_type, 'image', 'stroke', 'color'), '51,153,204,1'),
+      );
+      $form['options'][$geometry_type]['stroke'] = array(
+        '#type' => 'fieldset',
+        '#title' => 'Stroke',
+      );
+      $form['options'][$geometry_type]['stroke']['color'] = array(
+        '#type' => 'textfield',
+        '#title' => 'Color',
+        '#field_prefix' => 'rgba(',
+        '#field_suffix' => ')',
+        '#default_value' => $this->getOption(array($geometry_type, 'stroke', 'color'), '51,153,204,1'),
+      );
+      $form['options'][$geometry_type]['stroke']['width'] = array(
+        '#type' => 'textfield',
+        '#title' => 'Width',
+        '#default_value' => $this->getOption(array($geometry_type, 'stroke', 'width'), 1.25),
+      );
+      $form['options'][$geometry_type]['stroke']['lineDash'] = array(
+        '#type' => 'textfield',
+        '#title' => 'Width',
+        '#description' => 'Two integers separated by a comma. The comma is mandatory. Default to disable is <em>0,0</em>.',
+        '#default_value' => $this->getOption(array($geometry_type, 'stroke', 'lineDash'), '0,0'),
+      );
+      $form['options'][$geometry_type]['fill'] = array(
+        '#type' => 'fieldset',
+        '#title' => 'Fill',
+      );
+      $form['options'][$geometry_type]['fill']['color'] = array(
+        '#type' => 'textfield',
+        '#title' => 'Color',
+        '#field_prefix' => 'rgba(',
+        '#field_suffix' => ')',
+        '#default_value' => $this->getOption(array($geometry_type, 'fill', 'color'), '51,153,204,1'),
+      );
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function optionsFormSubmit($form, &$form_state) {
+    parent::optionsFormSubmit($form, $form_state);
+
+    $options = $this->getOptions();
+    foreach (Openlayers::getGeometryTypes() as $geometry_type => $geometry) {
+      if ((bool) $options[$geometry_type]['enabled'] === FALSE) {
+        unset($options[$geometry_type]);
+      }
+    }
+
+    $this->setOptions($options);
+    $form_state['values']['options'] = $options;
+    parent::optionsFormSubmit($form, $form_state);
   }
 
 }

--- a/src/Plugin/Style/Circle/js/Circle.js
+++ b/src/Plugin/Style/Circle/js/Circle.js
@@ -2,6 +2,9 @@ Drupal.openlayers.pluginManager.register({
   fs: 'openlayers.Style:Circle',
   init: function(data) {
     return function (feature, resolution) {
+      if (!(feature instanceof ol.Feature)) {
+        return null;
+      }
       var geometry = feature.getGeometry().getType();
       var geometry_style;
       if (goog.isDef(data.opt[geometry])) {

--- a/src/Plugin/Style/Circle/js/Circle.js
+++ b/src/Plugin/Style/Circle/js/Circle.js
@@ -3,10 +3,11 @@ Drupal.openlayers.pluginManager.register({
   init: function(data) {
     return function (feature, resolution) {
       var geometry = feature.getGeometry().getType();
+      var geometry_style;
       if (goog.isDef(data.opt[geometry])) {
-        var geometry_style = data.opt[geometry];
+        geometry_style = data.opt[geometry];
       }else {
-        var geometry_style = data.opt['default'];
+        geometry_style = data.opt['default'];
       }
       return [
         new ol.style.Style({
@@ -15,8 +16,9 @@ Drupal.openlayers.pluginManager.register({
               color: 'rgba(' + geometry_style.image.fill.color + ')'
             }),
             stroke: new ol.style.Stroke({
-              width: data.opt.stroke.width,
-              color: 'rgba(' + geometry_style.image.stroke.color + ')'
+              width: geometry_style.image.stroke.width,
+              color: 'rgba(' + geometry_style.image.stroke.color + ')',
+              lineDash: geometry_style.image.stroke.lineDash.split(',')
             }),
             radius: geometry_style.image.radius
           }),
@@ -25,7 +27,8 @@ Drupal.openlayers.pluginManager.register({
           }),
           stroke: new ol.style.Stroke({
             width: geometry_style.stroke.width,
-            color: 'rgba(' + geometry_style.stroke.color + ')'
+            color: 'rgba(' + geometry_style.stroke.color + ')',
+            lineDash: geometry_style.stroke.lineDash.split(',')
           })
         })
       ];

--- a/src/Plugin/Style/Circle/js/Circle.js
+++ b/src/Plugin/Style/Circle/js/Circle.js
@@ -1,26 +1,34 @@
 Drupal.openlayers.pluginManager.register({
   fs: 'openlayers.Style:Circle',
   init: function(data) {
-    return [
-      new ol.style.Style({
-        image: new ol.style.Circle({
+    return function (feature, resolution) {
+      var geometry = feature.getGeometry().getType();
+      if (goog.isDef(data.opt[geometry])) {
+        var geometry_style = data.opt[geometry];
+      }else {
+        var geometry_style = data.opt['default'];
+      }
+      return [
+        new ol.style.Style({
+          image: new ol.style.Circle({
+            fill: new ol.style.Fill({
+              color: 'rgba(' + geometry_style.image.fill.color + ')'
+            }),
+            stroke: new ol.style.Stroke({
+              width: data.opt.stroke.width,
+              color: 'rgba(' + geometry_style.image.stroke.color + ')'
+            }),
+            radius: geometry_style.image.radius
+          }),
           fill: new ol.style.Fill({
-            color: 'rgba(' + data.opt.fill.color + ')'
+            color: 'rgba(' + geometry_style.fill.color + ')'
           }),
           stroke: new ol.style.Stroke({
-            width: data.opt.stroke.width,
-            color: 'rgba(' + data.opt.stroke.color + ')'
-          }),
-          radius: data.opt.radius
-        }),
-        fill: new ol.style.Fill({
-          color: 'rgba(' + data.opt.color + ')'
-        }),
-        stroke: new ol.style.Stroke({
-            width: data.opt.stroke.width,
-            color: 'rgba(' + data.opt.stroke.color + ')'
+            width: geometry_style.stroke.width,
+            color: 'rgba(' + geometry_style.stroke.color + ')'
           })
-      })
-    ];
+        })
+      ];
+    };
   }
 });

--- a/src/Plugin/Style/RegularShape/RegularShape.php
+++ b/src/Plugin/Style/RegularShape/RegularShape.php
@@ -1,22 +1,23 @@
 <?php
 /**
  * @file
- * Style: Circle.
+ * Style: RegularShape.
  */
 
-namespace Drupal\openlayers\Plugin\Style\Circle;
+namespace Drupal\openlayers\Plugin\Style\RegularShape;
 use Drupal\openlayers\Component\Annotation\OpenlayersPlugin;
 use Drupal\openlayers\Openlayers;
 use Drupal\openlayers\Types\Style;
 
 /**
- * Class Circle.
+ * Class RegularShape.
  *
  * @OpenlayersPlugin(
- *  id = "Circle"
+ *  id = "RegularShape",
+ *  description = "Set regular shape style for vector features. The resulting shape will be a regular polygon when radius is provided, or a star when radius1 and radius2 are provided."
  * )
  */
-class Circle extends Style {
+class RegularShape extends Style {
   /**
    * @inheritDoc
    */
@@ -31,11 +32,43 @@ class Circle extends Style {
       '#title' => t('Image options'),
       '#collapsible' => FALSE,
     );
+    $form['options']['default']['image']['points'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Points',
+      '#default_value' => $this->getOption(array('default', 'image', 'points'), '4'),
+      '#required' => TRUE,
+      '#description' => 'Number of points for stars and regular polygons. In case of a polygon, the number of points is the number of sides.',
+    );
     $form['options']['default']['image']['radius'] = array(
       '#type' => 'textfield',
       '#title' => 'Radius',
       '#default_value' => $this->getOption(array('default', 'image', 'radius'), '5'),
+      '#description' => 'Radius of a regular polygon.',
+    );
+    $form['options']['default']['image']['radius1'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Radius1',
+      '#default_value' => $this->getOption(array('default', 'image', 'radius1'), NULL),
+      '#description' => 'Inner radius of a star.',
+    );
+    $form['options']['default']['image']['radius2'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Radius2',
+      '#default_value' => $this->getOption(array('default', 'image', 'radius2'), NULL),
+      '#description' => 'Outer radius of a star.',
+    );
+    $form['options']['default']['image']['angle'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Angle',
+      '#default_value' => $this->getOption(array('default', 'image', 'angle'), 0),
+      '#description' => 'Shape\'s angle in degrees. A value of 0 will have one of the shape\'s point facing up. Default value is 0.',
+    );
+    $form['options']['default']['image']['rotation'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Rotation',
+      '#default_value' => $this->getOption(array('default', 'image', 'rotation'), NULL),
       '#required' => TRUE,
+      '#description' => 'Rotation in degrees (positive rotation clockwise). Default is 0.',
     );
     $form['options']['default']['image']['fill'] = array(
       '#type' => 'fieldset',
@@ -69,7 +102,7 @@ class Circle extends Style {
       '#default_value' => $this->getOption(array('default', 'image', 'stroke', 'width'), '1.25'),
       '#required' => TRUE,
     );
-    $form['options']['default']['stroke']['lineDash'] = array(
+    $form['options']['default']['image']['stroke']['lineDash'] = array(
       '#type' => 'textfield',
       '#title' => 'Line dash',
       '#description' => 'Two integers separated by a comma. The comma is mandatory. Default to disable is <em>0,0</em>.',
@@ -127,10 +160,51 @@ class Circle extends Style {
         '#title' => t('Enable this geometry type ?'),
         '#default_value' => $enabled,
       );
+      $form['options'][$geometry_type]['image'] = array(
+        '#type' => 'fieldset',
+        '#title' => t('Image options'),
+        '#collapsible' => FALSE,
+      );
+      $form['options'][$geometry_type]['image']['points'] = array(
+        '#type' => 'textfield',
+        '#title' => 'Radius2',
+        '#default_value' => $this->getOption(array($geometry_type, 'image', 'points'), '4'),
+        '#description' => 'Number of points for stars and regular polygons. In case of a polygon, the number of points is the number of sides.',
+      );
       $form['options'][$geometry_type]['image']['radius'] = array(
         '#type' => 'textfield',
         '#title' => 'Radius',
         '#default_value' => $this->getOption(array($geometry_type, 'image', 'radius'), '5'),
+        '#description' => 'Radius of a regular polygon.',
+      );
+      $form['options'][$geometry_type]['image']['radius1'] = array(
+        '#type' => 'textfield',
+        '#title' => 'Radius',
+        '#default_value' => $this->getOption(array($geometry_type, 'image', 'radius1'), NULL),
+        '#description' => 'Inner radius of a star.',
+      );
+      $form['options'][$geometry_type]['image']['radius2'] = array(
+        '#type' => 'textfield',
+        '#title' => 'Radius1',
+        '#default_value' => $this->getOption(array($geometry_type, 'image', 'radius2'), NULL),
+        '#description' => 'Outer radius of a star.',
+      );
+      $form['options'][$geometry_type]['image']['angle'] = array(
+        '#type' => 'textfield',
+        '#title' => 'Angle',
+        '#default_value' => $this->getOption(array($geometry_type, 'image', 'angle'), 0),
+        '#description' => 'Shape\'s angle in degrees. A value of 0 will have one of the shape\'s point facing up. Default value is 0.',
+      );
+      $form['options'][$geometry_type]['image']['rotation'] = array(
+        '#type' => 'textfield',
+        '#title' => 'Rotation',
+        '#default_value' => $this->getOption(array($geometry_type, 'image', 'rotation'), NULL),
+        '#description' => 'Rotation in degrees (positive rotation clockwise). Default is 0.',
+      );
+      $form['options'][$geometry_type]['image']['fill'] = array(
+        '#type' => 'fieldset',
+        '#title' => t('Fill options'),
+        '#collapsible' => FALSE,
       );
       $form['options'][$geometry_type]['image']['fill']['color'] = array(
         '#type' => 'textfield',
@@ -138,26 +212,30 @@ class Circle extends Style {
         '#field_prefix' => 'rgba(',
         '#field_suffix' => ')',
         '#default_value' => $this->getOption(array($geometry_type, 'image', 'fill', 'color'), '255,255,255,0.4'),
+        '#required' => TRUE,
+      );
+      $form['options'][$geometry_type]['image']['stroke'] = array(
+        '#type' => 'fieldset',
+        '#title' => t('Stroke options'),
+        '#collapsible' => FALSE,
       );
       $form['options'][$geometry_type]['image']['stroke']['color'] = array(
         '#type' => 'textfield',
-        '#title' => 'Color',
+        '#title' => 'Stroke color',
         '#field_prefix' => 'rgba(',
         '#field_suffix' => ')',
         '#default_value' => $this->getOption(array($geometry_type, 'image', 'stroke', 'color'), '51,153,204,1'),
       );
       $form['options'][$geometry_type]['image']['stroke']['width'] = array(
         '#type' => 'textfield',
-        '#title' => 'Width',
-        '#default_value' => $this->getOption(array($geometry_type, 'image', 'stroke', 'width'), 1.25),
-        '#required' => TRUE,
+        '#title' => 'Stroke width',
+        '#default_value' => $this->getOption(array($geometry_type, 'image', 'stroke', 'width'), '1.25'),
       );
       $form['options'][$geometry_type]['image']['stroke']['lineDash'] = array(
         '#type' => 'textfield',
         '#title' => 'Line dash',
         '#description' => 'Two integers separated by a comma. The comma is mandatory. Default to disable is <em>0,0</em>.',
         '#default_value' => $this->getOption(array($geometry_type, 'image', 'stroke', 'lineDash'), '0,0'),
-        '#required' => TRUE,
       );
       $form['options'][$geometry_type]['stroke'] = array(
         '#type' => 'fieldset',
@@ -177,7 +255,7 @@ class Circle extends Style {
       );
       $form['options'][$geometry_type]['stroke']['lineDash'] = array(
         '#type' => 'textfield',
-        '#title' => 'Width',
+        '#title' => 'Line dash',
         '#description' => 'Two integers separated by a comma. The comma is mandatory. Default to disable is <em>0,0</em>.',
         '#default_value' => $this->getOption(array($geometry_type, 'stroke', 'lineDash'), '0,0'),
       );
@@ -212,5 +290,6 @@ class Circle extends Style {
     $form_state['values']['options'] = $options;
     parent::optionsFormSubmit($form, $form_state);
   }
+
 
 }

--- a/src/Plugin/Style/RegularShape/js/RegularShape.js
+++ b/src/Plugin/Style/RegularShape/js/RegularShape.js
@@ -1,0 +1,56 @@
+Drupal.openlayers.pluginManager.register({
+  fs: 'openlayers.Style:RegularShape',
+  init: function(data) {
+    return function (feature, resolution) {
+      var geometry = feature.getGeometry().getType();
+      var geometry_style;
+      if (goog.isDef(data.opt[geometry])) {
+        geometry_style = data.opt[geometry];
+      }else {
+        geometry_style = data.opt['default'];
+      }
+      var options = {
+        fill: new ol.style.Fill({
+          color: 'rgba(' + geometry_style.image.fill.color + ')'
+        }),
+        stroke: new ol.style.Stroke({
+          width: geometry_style.image.stroke.width,
+          color: 'rgba(' + geometry_style.image.stroke.color + ')',
+          lineDash: geometry_style.image.stroke.lineDash.split(',')
+        })
+      };
+
+      if (goog.isDef(geometry_style.image.radius)) {
+        options.radius = geometry_style.image.radius;
+      }
+      if (goog.isDef(geometry_style.image.points)) {
+        options.points = geometry_style.image.points;
+      }
+      if (goog.isDef(geometry_style.image.radius1)) {
+        options.radius1 = geometry_style.image.radius1;
+      }
+      if (goog.isDef(geometry_style.image.radius2)) {
+        options.radius2 = geometry_style.image.radius2;
+      }
+      if (goog.isDef(geometry_style.image.angle)) {
+        options.angle = geometry_style.image.angle * Math.PI / 180;
+      }
+      if (goog.isDef(geometry_style.image.rotation)) {
+        options.rotation = geometry_style.image.rotation * Math.PI / 180;
+      }
+      return [
+        new ol.style.Style({
+          image: new ol.style.RegularShape(options),
+          fill: new ol.style.Fill({
+            color: 'rgba(' + geometry_style.fill.color + ')'
+          }),
+          stroke: new ol.style.Stroke({
+            width: geometry_style.stroke.width,
+            color: 'rgba(' + geometry_style.stroke.color + ')',
+            lineDash: geometry_style.stroke.lineDash.split(',')
+          })
+        })
+      ];
+    };
+  }
+});

--- a/src/Plugin/Style/RegularShape/js/RegularShape.js
+++ b/src/Plugin/Style/RegularShape/js/RegularShape.js
@@ -2,6 +2,9 @@ Drupal.openlayers.pluginManager.register({
   fs: 'openlayers.Style:RegularShape',
   init: function(data) {
     return function (feature, resolution) {
+      if (!(feature instanceof ol.Feature)) {
+        return null;
+      }
       var geometry = feature.getGeometry().getType();
       var geometry_style;
       if (goog.isDef(data.opt[geometry])) {


### PR DESCRIPTION
* It's now possible to define a style for each feature's geometry type.
* Adding RegularShape icon style plugin and examples.
* Add Random source and style plugin.
* Update Select interaction, allows you to set a particular style when a feature is selected.
* Added a new example map: Features & Interactions

![openlayers d7x x230 local](https://cloud.githubusercontent.com/assets/252042/9025190/f14d07b4-38f9-11e5-8dcc-49051c9a2207.png)

![openlayers d7x x230 local2](https://cloud.githubusercontent.com/assets/252042/9025189/ec2a8478-38f9-11e5-80fa-e51ac48aa545.png)

![edit map openlayers_map_ui_default d7x x230 local](https://cloud.githubusercontent.com/assets/252042/9025863/cfa61542-3917-11e5-8f2f-029af29eb2cf.png)
